### PR TITLE
Add basic Swagger UI definition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Then run the following commands to bootstrap your environment ::
     git clone https://github.com/catherinedevlin/crime_data
     cd crime_data
     pip install -r requirements/dev.txt
-    bower install
+    npm install && npm run swagger
     flask run
 
 You will see a pretty welcome screen.
@@ -39,6 +39,7 @@ database tables and perform the initial migration ::
     flask db upgrade
     flask run
 
+You can find the Swagger UI API documentation page at ``http://127.0.0.1:5000/static/libs/swagger/index.html?url=/static/crime-data-api-swagger.yaml``
 
 Deployment
 ----------

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "crime_data",
-  "dependencies": {
-    "bootstrap": "~3.2.0",
-    "jQuery": "~2.1.3"
-  }
-}

--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -5,6 +5,7 @@ import io
 
 import flask_restful as restful
 from flask import Flask, render_template
+from flask_cors import CORS, cross_origin
 
 import crime_data.resources.agencies
 import crime_data.resources.incidents
@@ -25,6 +26,7 @@ def create_app(config_object=ProdConfig):
     """
     app = Flask(__name__)
     app.config.from_object(config_object)
+    CORS(app)
     register_extensions(app)
     register_blueprints(app)
     register_errorhandlers(app)

--- a/crime_data/static/crime-data-api-swagger.yaml
+++ b/crime_data/static/crime-data-api-swagger.yaml
@@ -1,0 +1,58 @@
+swagger: '2.0'
+info:
+  title: Crime Data API
+  description: RESTful API service providing data and statistics on crime in the USA
+  version: "1.0.0"
+# the domain of the service
+host: crime-data-api.fr.cloud.gov
+# array of all schemes that your API supports
+schemes:
+  - https
+# will be prefixed to all paths
+basePath: /
+produces:
+  - application/json
+paths:
+  /incidents:
+    get:
+      summary: NIBRS incidents
+      description: |
+        Incidents reported to the FBI with the National Incident Based Reporting Standard (NIBRS)
+      parameters:
+        - name: ori
+          in: query
+          description: Originating Reference ID (ORI) refers to a law enforcement agency
+          type: string
+      responses:
+        200:
+          description: An array of incidents
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Incident'
+        default:
+          description: 'Unauthenticated error'
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Incident:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      fields:
+        type: string
+
+  Error:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      fields:
+        type: string

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "crime-data-api",
+  "version": "1.0.0",
+  "description": "RESTful API service providing data and statistics on crime in the USA",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "swagger": "npm run swagger:mkdir && npm run swagger:cp",
+    "swagger:mkdir": "mkdir crime_data/static/libs/swagger",
+    "swagger:cp": "cp -r node_modules/swagger-ui/dist/* crime_data/static/libs/swagger/",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/18F/crime-data-api.git"
+  },
+  "keywords": [],
+  "author": "Jeremia Kimelman <jeremia.kimelman@gsa.gov>",
+  "license": "Public Domain",
+  "bugs": {
+    "url": "https://github.com/18F/crime-data-api/issues"
+  },
+  "homepage": "https://github.com/18F/crime-data-api#readme",
+  "dependencies": {
+    "swagger-ui": "^2.2.5"
+  }
+}

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,6 +8,7 @@ Jinja2==2.8
 itsdangerous==0.24
 click>=5.0
 Flask-RESTful==0.3.5
+Flask-Cors==3.0.2
 
 # Database
 Flask-SQLAlchemy==2.1


### PR DESCRIPTION
Adds a very basic swagger configuration file and some build steps to install `swagger-ui`. I didn't even cover all of the endpoints, or the values that they take and also the fact that all requests require an API key.

I also replaced `bower.json` with `package.json` as it is [18F's policy not to use `bower`](https://pages.18f.gov/frontend/#bower).

