### PR TITLE
Use a "user provided service" to store sensitive information like api keys

### DIFF
--- a/crime_data/resources/helpers.py
+++ b/crime_data/resources/helpers.py
@@ -1,3 +1,4 @@
+import json
 import os
 from sqlalchemy import sql
 
@@ -12,8 +13,13 @@ def add_standard_arguments(parser):
 
 
 def verify_api_key(args):
-    if os.getenv('VCAP_APPLICATION'):
-        if args['api_key'] != os.getenv('API_KEY'):
+    if os.getenv('VCAP_SERVICES'):
+        service_env = json.loads(os.getenv('VCAP_SERVICES'))
+        cups_name = 'crime-data-api-creds'
+        user_provided =service_env['user-provided']
+        creds = filter(lambda x: x['name']==cups_name, user_provided).pop()
+        key = creds['credentials']['API_KEY']
+        if args['api_key'] != key:
             raise Exception('Ask Catherine for API key')
 
 def expand_delimited_items(lst, sep=','):

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,3 +8,4 @@ env:
   FLASK_APP: autoapp.py
 services:
 - crime-data-api-db
+- crime-data-api-creds


### PR DESCRIPTION
We use `autopilot` for continuous deploys and as a result env variables must be set in either the `manifest.yml` file or in a user provided service. We need to keep sensitive information like the api key in a cloud.gov service.

* Updates the manifest to bind the service to each new application.
* Parses the `VCAP_SERVICES` environment variable to get the `API_KEY`