### PR TITLE
Remove SERVER_NAME from prod config settings

### DIFF
--- a/crime_data/settings.py
+++ b/crime_data/settings.py
@@ -27,7 +27,6 @@ class ProdConfig(Config):
     DEBUG_TB_ENABLED = False  # Disable Debug toolbar
     port = os.getenv('PORT') or 5000
     server = 'crime-data-api.fr.cloud.gov'
-    SERVER_NAME = '{}:{}'.format(server, port)
 
 
 class DevConfig(Config):


### PR DESCRIPTION
I think this variable is used by Flask to support subdomains ([relevant Flask docs](http://flask.pocoo.org/docs/0.11/config/#builtin-configuration-values)) but it is causing our app to not run properly at all, either locally or on cloud.gov

I've gone ahead and removed it, pushed to cloud.gov in a temp app and it seems to have worked.

