### PR TITLE
pagination for /count/

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -3,17 +3,17 @@
 import csv
 import io
 
-import flask_restful as restful
-from flask import Flask, render_template
-from flask_cors import CORS, cross_origin
-
 import crime_data.resources.agencies
 import crime_data.resources.incidents
+import flask_restful as restful
 from crime_data import commands, public, user
 from crime_data.assets import assets
 from crime_data.common.models import db
-from crime_data.extensions import bcrypt, cache, csrf_protect, db, debug_toolbar, login_manager, migrate
+from crime_data.extensions import (bcrypt, cache, csrf_protect, db,
+                                   debug_toolbar, login_manager, migrate)
 from crime_data.settings import ProdConfig
+from flask import Flask, render_template
+from flask_cors import CORS, cross_origin
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -1,8 +1,9 @@
 import random
 
+from flask_restful import Resource
 # import celery
 from flask_sqlalchemy import SignallingSession, SQLAlchemy
-from flask_restful import Resource
+
 
 class RoutingSession(SignallingSession):
     """Route requests to database leader or follower as appropriate.
@@ -46,14 +47,16 @@ class RoutingSQLAlchemy(SQLAlchemy):
     def create_session(self, options):
         return RoutingSession(self, **options)
 
+
 class CdeResource(Resource):
     __abstract__ = True
+
     def _stringify(self, data):
         """Avoid JSON serialization errors
         by converting values in list of dicts
         into strings."""
-        return [{k: (d[k] if hasattr(d[k], '__pow__') else str(d[k])) for k in d}
-        for d in (r._asdict() for r in data)]
+        return [{k: (d[k] if hasattr(d[k], '__pow__') else str(d[k]))
+                 for k in d} for d in (r._asdict() for r in data)]
 
 
 db = RoutingSQLAlchemy()

--- a/crime_data/common/models.py
+++ b/crime_data/common/models.py
@@ -1,14 +1,15 @@
 # coding: utf-8
+import datetime
+from decimal import Decimal
+
 import flask_restful as restful
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import (BigInteger, Boolean, Column, DateTime, Float,
                         ForeignKey, Integer, SmallInteger, String, Text,
-                        UniqueConstraint, text, func)
+                        UniqueConstraint, func, text)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import label
-from decimal import Decimal
-import datetime
 
 db = SQLAlchemy()
 
@@ -2841,8 +2842,8 @@ class QueryWithAggregates(object):
         types = [c.type.python_type for c in col.prop.columns]
         if types in ([int, ], [float, ], [Decimal, ]):
             return True
-        if (types in ([datetime.datetime, ], [datetime.date, ])
-            and aggregate in (func.min, func.max)):
+        if (types in ([datetime.datetime, ], [datetime.date, ]) and
+                aggregate in (func.min, func.max)):
             return True
         return False
 
@@ -2871,6 +2872,9 @@ class QueryWithAggregates(object):
 
 class RetaMonthQuery(QueryWithAggregates):
 
-    COL_NAME_MAP = {'year': 'data_year', 'state': 'state_abbr', 'offense': 'offense_subcat_name'}
-    tables = [RetaMonth, RefAgency, RefState, RetaMonthOffenseSubcat, RetaOffenseSubcat]
+    COL_NAME_MAP = {'year': 'data_year',
+                    'state': 'state_abbr',
+                    'offense': 'offense_subcat_name'}
+    tables = [RetaMonth, RefAgency, RefState, RetaMonthOffenseSubcat,
+              RetaOffenseSubcat]
     seed_col = 'total_actual_count'

--- a/crime_data/public/forms.py
+++ b/crime_data/public/forms.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """Public forms."""
+from crime_data.user.models import User
 from flask_wtf import Form
 from wtforms import PasswordField, StringField
 from wtforms.validators import DataRequired
-
-from crime_data.user.models import User
 
 
 class LoginForm(Form):

--- a/crime_data/public/views.py
+++ b/crime_data/public/views.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Public section, including homepage and signup."""
-from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
-from flask_login import login_required, login_user, logout_user
-
 from crime_data.extensions import login_manager
 from crime_data.public.forms import LoginForm
 from crime_data.user.forms import RegisterForm
 from crime_data.user.models import User
 from crime_data.utils import flash_errors
+from flask import (Blueprint, flash, redirect, render_template, request,
+                   send_file, url_for)
+from flask_login import login_required, login_user, logout_user
 
 blueprint = Blueprint('public', __name__, static_folder='../static')
 

--- a/crime_data/resources/helpers.py
+++ b/crime_data/resources/helpers.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from sqlalchemy import sql
+from flask.ext.sqlalchemy import Pagination
 
 
 def add_standard_arguments(parser):
@@ -34,7 +35,13 @@ def expand_delimited_items(lst, sep=','):
 
 
 def with_metadata(results, args):
-    results = results.paginate(args['page'], args['per_page'])
+    try:
+        results = results.paginate(args['page'], args['per_page'])
+    except AttributeError:
+        page = results.limit(args['per_page']).offset((args['page']-1)*args['per_page'])
+        items = [row._asdict() for row in page]
+        results = Pagination(results, page=args['page'], per_page=args['per_page'], total=results.count(), 
+                             items=items) 
     return {'results': results.items,
             'pagination': {
                 'count': results.total,

--- a/crime_data/resources/helpers.py
+++ b/crime_data/resources/helpers.py
@@ -1,8 +1,8 @@
 import json
 import os
 
-from sqlalchemy import sql
 from flask.ext.sqlalchemy import Pagination
+from sqlalchemy import sql
 
 
 def add_standard_arguments(parser):
@@ -19,8 +19,8 @@ def verify_api_key(args):
     if os.getenv('VCAP_SERVICES'):
         service_env = json.loads(os.getenv('VCAP_SERVICES'))
         cups_name = 'crime-data-api-creds'
-        user_provided =service_env['user-provided']
-        creds = filter(lambda x: x['name']==cups_name, user_provided).pop()
+        user_provided = service_env['user-provided']
+        creds = filter(lambda x: x['name'] == cups_name, user_provided).pop()
         key = creds['credentials']['API_KEY']
         if args['api_key'] != key:
             raise Exception('Ask Catherine for API key')
@@ -38,10 +38,14 @@ def with_metadata(results, args):
     try:
         results = results.paginate(args['page'], args['per_page'])
     except AttributeError:
-        page = results.limit(args['per_page']).offset((args['page']-1)*args['per_page'])
+        page = results.limit(args['per_page']).offset((args['page'] - 1) *
+                                                      args['per_page'])
         items = [row._asdict() for row in page]
-        results = Pagination(results, page=args['page'], per_page=args['per_page'], total=results.count(), 
-                             items=items) 
+        results = Pagination(results,
+                             page=args['page'],
+                             per_page=args['per_page'],
+                             total=results.count(),
+                             items=items)
     return {'results': results.items,
             'pagination': {
                 'count': results.total,

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -142,5 +142,5 @@ class IncidentsCount(CdeResource):
         else:
             fields = []
         result = models.RetaMonthQuery(aggregated=fields, grouped=by)
-        return self._stringify(result.qry)
+        return with_metadata(result.qry, args)
         # This result isn't working with @marshal_with

--- a/crime_data/user/models.py
+++ b/crime_data/user/models.py
@@ -2,10 +2,10 @@
 """User models."""
 import datetime as dt
 
-from flask_login import UserMixin
-
-from crime_data.database import Column, Model, SurrogatePK, db, reference_col, relationship
+from crime_data.database import (Column, Model, SurrogatePK, db, reference_col,
+                                 relationship)
 from crime_data.extensions import bcrypt
+from flask_login import UserMixin
 
 
 class Role(SurrogatePK, Model):

--- a/tests/functional/test_incidents.py
+++ b/tests/functional/test_incidents.py
@@ -149,43 +149,47 @@ class TestIncidentsCountEndpoint:
     def test_instances_count_exists(self, testapp):
         res = testapp.get('/incidents/count/')
         assert res.status_code == 200
+        
+    def test_incidents_endpoint_includes_metadata(self, user, testapp):
+        res = testapp.get('/incidents/count/')
+        assert 'pagination' in res.json
 
     def test_instances_count_returns_counts(self, testapp):
         res = testapp.get('/incidents/count/')
-        assert isinstance(res.json, list)
-        assert 'total_actual_count' in res.json[0]
+        assert isinstance(res.json['results'], list)
+        assert 'total_actual_count' in res.json['results'][0]
 
     def test_instances_count_groups_by_year_by_default(self, testapp):
         res = testapp.get('/incidents/count/')
-        years = [row['year'] for row in res.json]
+        years = [row['year'] for row in res.json['results']]
         assert len(years) == len(set(years))
 
     def test_instances_count_groups_by_agency_id(self, testapp):
         res = testapp.get('/incidents/count/?by=agency_id')
-        agency_ids = [row['agency_id'] for row in res.json]
+        agency_ids = [row['agency_id'] for row in res.json['results']]
         assert len(agency_ids) == len(set(agency_ids))
 
     def test_instances_count_groups_by_agency_id_any_year(self, testapp):
         res = testapp.get('/incidents/count/?by=agency_id,year')
-        rows = [(row['year'], row['agency_id']) for row in res.json]
+        rows = [(row['year'], row['agency_id']) for row in res.json['results']]
         assert len(rows) == len(set(rows))
 
     def test_instances_count_groups_by_state(self, testapp):
         res = testapp.get('/incidents/count/?by=state')
-        rows = [row['state'] for row in res.json]
+        rows = [row['state'] for row in res.json['results']]
         assert len(rows) == len(set(rows))
 
     def test_instances_count_groups_by_offense(self, testapp):
         res = testapp.get('/incidents/count/?by=offense')
-        rows = [row['offense'] for row in res.json]
+        rows = [row['offense'] for row in res.json['results']]
         assert len(rows) == len(set(rows))
 
     def test_instances_count_shows_fields_in_month(self, testapp):
         res = testapp.get('/incidents/count/?fields=leoka_felony')
-        for row in res.json:
+        for row in res.json['results']:
             assert 'leoka_felony' in row
 
     def test_instances_count_sorts_by_state(self, testapp):
         res = testapp.get('/incidents/count/?by=state')
-        state_names = [r['state'] for r in res.json]
+        state_names = [r['state'] for r in res.json['results']]
         assert state_names == sorted(state_names)


### PR DESCRIPTION
- API results include metadata with pagination info, even for /count/ endpoint formed by SQLAlchemy Core query

- YAPF and iSort applied for consistent formatting