### PR TITLE
Renamed import to avoid namespace collision

### DIFF
--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -3,7 +3,7 @@
 import os
 
 from flask_marshmallow import Marshmallow
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields as marsh_fields
 
 from . import models
 
@@ -12,28 +12,28 @@ ma = Marshmallow()
 
 # Schemas for request parsing
 class ArgumentsSchema(Schema):
-    page = fields.Integer(missing=1)
-    per_page = fields.Integer(missing=10)
-    fields = fields.String()
+    page = marsh_fields.Integer(missing=1)
+    per_page = marsh_fields.Integer(missing=10)
+    fields = marsh_fields.String()
     if os.getenv('VCAP_APPLICATION'):
-        api_key = fields.String(
+        api_key = marsh_fields.String(
             required=True,
             error_messages={'required': 'Get API key from Catherine'})
 
 
 class IncidentArgsSchema(ArgumentsSchema):
-    incident_hour = fields.Integer()
-    crime_against = fields.String()
-    offense_code = fields.String()
-    offense_name = fields.String()
-    offense_category_name = fields.String()
-    method_entry_code = fields.String()
-    location_code = fields.String()
-    location_name = fields.String()
+    incident_hour = marsh_fields.Integer()
+    crime_against = marsh_fields.String()
+    offense_code = marsh_fields.String()
+    offense_name = marsh_fields.String()
+    offense_category_name = marsh_fields.String()
+    method_entry_code = marsh_fields.String()
+    location_code = marsh_fields.String()
+    location_name = marsh_fields.String()
 
 
 class IncidentCountArgsSchema(ArgumentsSchema):
-    by = fields.String(missing='data_year')
+    by = marsh_fields.String(missing='data_year')
 
 # Schemas for data serialization
 '''


### PR DESCRIPTION
Namespace Collision issue:

from marshmallow import Schema, fields
...
    **fields** = **fields**.String()
    if os.getenv('VCAP_APPLICATION'):
        api_key = **fields**.String(...      # Overwriting module with String.
...


