### PR TITLE
Remove npm steps from project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Then run the following commands to bootstrap your environment :
 git clone https://github.com/18F/crime-data-api
 cd crime-data-api
 pip install -r requirements/dev.txt
-npm install && npm run swagger
 flask run
 ```
 


### PR DESCRIPTION
We reached a point where we wanted to actually check in our javascript dependencies to the repository so we can modify them. I forgot to remove the step from the README