### PR TITLE
Added initial incidents endpoint csv support

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -70,8 +70,6 @@ class CdeResource(Resource):
             
             # create the csv writer object
             si = StringIO()
-            #dat = open('/tmp/out.csv', 'w')
-            #csvwriter = csv.writer(dat)
             csvwriter = csv.writer(si)
             keys = {}
 
@@ -81,7 +79,6 @@ class CdeResource(Resource):
                 if hasattr(v, 'many'):
                     list_fields.append(k)
 
-            #list_fields = ['offenders', 'offenses', 'property', 'victims', 'arrestees', 'agency']
             to_csv = []
 
             # Organize Data
@@ -107,8 +104,6 @@ class CdeResource(Resource):
                     csvwriter.writerow(header)
                     count += 1
                 csvwriter.writerow(cs.values())
-
-            #dat.close()
 
         return si.getvalue().strip('\r\n')
 

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -68,18 +68,17 @@ class CdeResource(Resource):
             import csv
             from io import StringIO
 
+            #dat = open('/tmp/out.csv', 'w')
             # create the csv writer object
             si = StringIO()
             csvwriter = csv.writer(si)
             keys = {}
-            list_fields = ['offenders', 'victims', 'arrestees']
+            # These are fields that can contain nested objects and/or lists (many to many)
+            list_fields = ['offenders', 'offenses', 'property', 'victims', 'arrestees', 'agency']
             to_csv = []
 
             # Organize Data
             for d in data['results']:
-                for k,i in d.items():
-                    if not i:
-                        d[k] = 0
                 to_csv_dict = {}
                 for base_field in list_fields:
                     to_csv_dict[base_field] = d[base_field]
@@ -90,7 +89,7 @@ class CdeResource(Resource):
                     base_field = k.split(':')[0]
                     leaf_field = k.split(':')[-1]
                     if base_field not in list_fields:
-                        to_csv_dict[base_field] = v
+                        to_csv_dict[base_field + '.' + leaf_field] = v
 
                 to_csv.append(to_csv_dict)
 
@@ -100,7 +99,6 @@ class CdeResource(Resource):
                     header = cs.keys()
                     csvwriter.writerow(header)
                     count += 1
-
                 csvwriter.writerow(cs.values())
 
         return si.getvalue().strip('\r\n')

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -105,8 +105,6 @@ class CdeResource(Resource):
 
         return si.getvalue().strip('\r\n')
 
-
-
     def _stringify(self, data):
         """Avoid JSON serialization errors
         by converting values in list of dicts

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -279,7 +279,7 @@ class TableFamily:
     def query(self):
 
         self._build_map()
-        self.print_map()
+        #self.print_map()
         qry = self.base_table.table.query
         for table in self.tables:
             if table.join is None:

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -279,7 +279,7 @@ class TableFamily:
     def query(self):
 
         self._build_map()
-        #self.print_map()
+        self.print_map()
         qry = self.base_table.table.query
         for table in self.tables:
             if table.join is None:

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -22,7 +22,6 @@ class ArgumentsSchema(Schema):
             required=True,
             error_messages={'required': 'Get API key from Catherine'})
 
-
 class AgenciesIncidentArgsSchema(ArgumentsSchema):
     incident_hour = marsh_fields.Integer()
     crime_against = marsh_fields.String()

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -13,6 +13,7 @@ ma = Marshmallow()
 
 # Schemas for request parsing
 class ArgumentsSchema(Schema):
+    output = marsh_fields.String(missing='json')
     page = marsh_fields.Integer(missing=1)
     per_page = marsh_fields.Integer(missing=10)
     fields = marsh_fields.String()

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -23,6 +23,8 @@ class IncidentsList(CdeResource):
         self.verify_api_key(args)
         filters = self.filters(args)
         qry = self.tables.filtered(filters)
+        if args['output'] == 'csv':
+            return self.output_serialize(self.with_metadata(qry, args))
         return self.with_metadata(qry, args)
 
 

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -24,7 +24,7 @@ class IncidentsList(CdeResource):
         filters = self.filters(args)
         qry = self.tables.filtered(filters)
         if args['output'] == 'csv':
-            return self.output_serialize(self.with_metadata(qry, args))
+            return self.output_serialize(self.with_metadata(qry, args), self.schema)
         return self.with_metadata(qry, args)
 
 

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -6,6 +6,7 @@ from crime_data.common.marshmallow_schemas import (ArgumentsSchema,
                                                    IncidentCountArgsSchema)
 from webargs.flaskparser import use_args
 
+from flask import make_response
 
 def _is_string(col):
     col0 = list(col.base_columns)[0]
@@ -24,7 +25,10 @@ class IncidentsList(CdeResource):
         filters = self.filters(args)
         qry = self.tables.filtered(filters)
         if args['output'] == 'csv':
-            return self.output_serialize(self.with_metadata(qry, args), self.schema)
+            output = make_response(self.output_serialize(self.with_metadata(qry, args), self.schema))
+            output.headers["Content-Disposition"] = "attachment; filename=incidents.csv"
+            output.headers["Content-type"] = "text/csv"
+            return output
         return self.with_metadata(qry, args)
 
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -47,3 +47,4 @@ Flask-RESTful==0.3.5
 flask-marshmallow==0.7.0
 marshmallow-sqlalchemy==0.12.0
 webargs==1.4.0
+flatdict==1.2.0


### PR DESCRIPTION
This is the initial stab at csv support. We still need to add support for file header settings, and file download. Right now it just outputs text.

usage:
/incidents/?output=csv