### PR TITLE
Fix pagination

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import random
 from functools import wraps
@@ -9,6 +10,8 @@ from flask_restful import Resource, abort, current_app
 # import celery
 from flask_sqlalchemy import SignallingSession, SQLAlchemy
 from sqlalchemy import and_, func
+from sqlalchemy_pagination import paginate
+
 
 def tuning_page(f):
     @wraps(f)
@@ -65,8 +68,8 @@ class RoutingSession(SignallingSession):
 
         return super().get_bind(mapper=mapper, clause=clause)
 
-class QueryTraits(object):
 
+class QueryTraits(object):
     @classmethod
     def get_fields(cls, agg_fields, fields):
         """Builds the query's SELECT clause.
@@ -89,7 +92,7 @@ class QueryTraits(object):
         for group in group_bys:
             if group in cls.get_filter_map():
                 query = (query.group_by(cls.get_filter_map()[group])
-                    .order_by(cls.get_filter_map()[group]))
+                         .order_by(cls.get_filter_map()[group]))
         return query
 
     @classmethod
@@ -113,29 +116,31 @@ class QueryTraits(object):
                     query = query.filter(getattr(col, comparitor)(val))
 
         # Apply all other filters.
-        for filter,value in parsed.items():
+        for filter, value in parsed.items():
             if filter in cls.get_filter_map():
                 col = cls.get_filter_map()[filter]
                 query = query.filter(col.ilike('%' + value + '%'))
 
         return query
 
+
 class RoutingSQLAlchemy(SQLAlchemy):
     def create_session(self, options):
         return RoutingSession(self, **options)
+
 
 class CdeResource(Resource):
     __abstract__ = True
     schema = None
 
     OPERATORS = {'!=': '__ne__',
-             '>=': '__ge__',
-             '<=': '__le__',
-             '>': '__gt__',
-             '<': '__le__',
-             '==': '__eq__', }
+                 '>=': '__ge__',
+                 '<=': '__le__',
+                 '>': '__gt__',
+                 '<': '__le__',
+                 '==': '__eq__', }
 
-    def output_serialize(self, data, schema = None,format='csv'):
+    def output_serialize(self, data, schema=None, format='csv'):
         """ Very limited csv parsing of output data.
         Uses Marshmallow schema to determine which fields are nested,
         and stores raw json for these fields.
@@ -155,7 +160,7 @@ class CdeResource(Resource):
 
             # These are fields that can contain nested objects and/or lists
             list_fields = []
-            for k,v in schema.declared_fields.items():
+            for k, v in schema.declared_fields.items():
                 if hasattr(v, 'many'):
                     list_fields.append(k)
 
@@ -169,7 +174,7 @@ class CdeResource(Resource):
 
                 flat = flatdict.FlatDict(d)
 
-                for k,v in flat.items():
+                for k, v in flat.items():
                     base_field = k.split(':')[0]
                     leaf_field = k.split(':')[-1]
                     if base_field not in list_fields:
@@ -198,18 +203,27 @@ class CdeResource(Resource):
         return dict(zip(fieldTuple, res))
 
     def with_metadata(self, results, args):
-        results = results.paginate(args['page'], args['per_page'])
         if self.schema:
-            items = self.schema.dump(results.items).data
+            paginated = results.distinct().limit(args['per_page']).offset(
+                (args['page'] - 1) * args['per_page'])
+            count = results.distinct().count()
+            return {'results': self.schema.dump(paginated),
+                    'pagination': {
+                        'count': count,
+                        'page': args['page'],
+                        'pages': math.ceil(count / args['per_page']),
+                        'per_page': args['per_page'],
+                    }, }
         else:
+            results = results.paginate(args['page'], args['per_page'])
             items = self._stringify(results.items)
-        return {'results': items,
-                'pagination': {
-                    'count': results.total,
-                    'page': results.page,
-                    'pages': results.pages,
-                    'per_page': results.per_page,
-                }, }
+            return {'results': items,
+                    'pagination': {
+                        'count': results.total,
+                        'page': results.page,
+                        'pages': results.pages,
+                        'per_page': results.per_page,
+                    }, }
 
     def verify_api_key(self, args):
         if os.getenv('VCAP_SERVICES'):

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -1,6 +1,6 @@
 from flask import abort
 from flask.ext.sqlalchemy import Pagination
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, distinct
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import label
 
@@ -11,45 +11,56 @@ from crime_data.extensions import db
 
 session = db.session
 
+
 class CdeRefState(models.RefState):
     pass
+
 
 class CdeNibrsAge(models.NibrsAge):
     pass
 
+
 class CdeNibrsOffenseType(models.NibrsOffenseType):
     pass
+
 
 class CdeNibrsWeapon(models.NibrsWeapon):
     pass
 
+
 class CdeNibrsWeaponType(models.NibrsWeaponType):
     pass
+
 
 class CdeRefRace(models.RefRace):
     pass
 
+
 class CdeRefCity(models.RefCity):
     pass
 
+
 class CdeRetaMonthOffenseSubcat(models.RetaMonthOffenseSubcat):
     pass
+
 
 class CdeRetaOffense(models.RetaOffense):
     pass
 
+
 class CdeRetaMonthOffenseSubcat(models.RetaMonthOffenseSubcat):
     pass
+
 
 class CdeRetaOffenseSubcat(models.RetaOffenseSubcat):
     pass
 
-class CdeRefAgency(models.RefAgency, QueryTraits):
 
+class CdeRefAgency(models.RefAgency, QueryTraits):
     @staticmethod
     def get_filter_map():
         return {'state': CdeRefState.state_abbr.label('state'),
-        'city': CdeRefCity.city_name.label('city') }
+                'city': CdeRefCity.city_name.label('city')}
 
     def get(ori=None, filters=None, args=None):
         # Base Query
@@ -63,25 +74,33 @@ class CdeRefAgency(models.RefAgency, QueryTraits):
         query = CdeRefAgency.apply_filters(query, filters, args)
 
         return query
+
     pass
+
 
 class CdeNibrsEthnicity(models.NibrsEthnicity):
     pass
 
+
 class CdeNibrsVictim(models.NibrsVictim):
     pass
+
 
 class CdeNibrsOffender(models.NibrsOffender):
     pass
 
+
 class CdeNibrsMonth(models.NibrsMonth):
     pass
+
 
 class CdeNibrsOffense(models.NibrsOffense):
     pass
 
+
 class CdeNibrsLocationType(models.NibrsLocationType):
     pass
+
 
 class CdeNibrsIncident(models.NibrsIncident, QueryTraits):
 
@@ -94,7 +113,6 @@ class CdeNibrsIncident(models.NibrsIncident, QueryTraits):
     arrestee_race = aliased(CdeRefRace, name='arrestee_race')
     arrestee_age = aliased(CdeNibrsAge, name='arrestee_age')
     arrestee_ethnicity = aliased(CdeNibrsEthnicity, name='arrestee_ethnicity')
-
     '''''
     Extends models.NibrsIncident.
     ''' ''
@@ -102,32 +120,38 @@ class CdeNibrsIncident(models.NibrsIncident, QueryTraits):
     # Maps API filter to DB column name.
     @staticmethod
     def get_filter_map():
-        return {'state': CdeRefState.state_abbr.label('state'),
-        'city': CdeRefCity.city_name.label('city'),
-        'month':CdeNibrsMonth.month_num,
-        'year':CdeNibrsMonth.data_year,
-        'ori': CdeRefAgency.ori,
-        'offense': CdeNibrsOffenseType.offense_name,
-        'offense.location': CdeNibrsLocationType.location_name,
-        'victim.ethnicity': 
-        CdeNibrsIncident.victim_ethnicity.ethnicity_name.label('victim.ethnicity'),
-        'offender.ethnicity': 
-        CdeNibrsIncident.offender_ethnicity.ethnicity_name.label('offender.ethnicity'), 
-        'victim.race_code': 
-        CdeNibrsIncident.victim_race.race_code.label('victim.race_code'),
-        'victim.age_code': 
-        CdeNibrsIncident.victim_age.age_code.label('victim.age_code'),
-        'offender.race_code': 
-        CdeNibrsIncident.offender_race.race_code.label('offender.race_code'),
-        'offender.age_code': 
-        CdeNibrsIncident.offender_age.age_code.label('offender.age_code'),
-        'arrestee.race_code': 
-        CdeNibrsIncident.arrestee_race.race_code.label('arestee.race_code'),
-        'arrestee.age_code': 
-        CdeNibrsIncident.arrestee_age.age_code.label('arestee.age_code'),
-        'arrestee.ethnicity': 
-        CdeNibrsIncident.arrestee_ethnicity.ethnicity_name.label('arrestee.ethnicity'),}
-
+        return {
+            'state': CdeRefState.state_abbr.label('state'),
+            'city': CdeRefCity.city_name.label('city'),
+            'month': CdeNibrsMonth.month_num,
+            'year': CdeNibrsMonth.data_year,
+            'ori': CdeRefAgency.ori,
+            'offense': CdeNibrsOffenseType.offense_name,
+            'offense.location': CdeNibrsLocationType.location_name,
+            'victim.ethnicity':
+            CdeNibrsIncident.victim_ethnicity.ethnicity_name.label(
+                'victim.ethnicity'),
+            'offender.ethnicity':
+            CdeNibrsIncident.offender_ethnicity.ethnicity_name.label(
+                'offender.ethnicity'),
+            'victim.race_code':
+            CdeNibrsIncident.victim_race.race_code.label('victim.race_code'),
+            'victim.age_code':
+            CdeNibrsIncident.victim_age.age_code.label('victim.age_code'),
+            'offender.race_code':
+            CdeNibrsIncident.offender_race.race_code.label(
+                'offender.race_code'),
+            'offender.age_code':
+            CdeNibrsIncident.offender_age.age_code.label('offender.age_code'),
+            'arrestee.race_code':
+            CdeNibrsIncident.arrestee_race.race_code.label(
+                'arestee.race_code'),
+            'arrestee.age_code':
+            CdeNibrsIncident.arrestee_age.age_code.label('arestee.age_code'),
+            'arrestee.ethnicity':
+            CdeNibrsIncident.arrestee_ethnicity.ethnicity_name.label(
+                'arrestee.ethnicity'),
+        }
 
     @staticmethod
     def get_nibrs_incident_by_ori(ori=None, filters=None, by=None, args=None):
@@ -147,64 +171,69 @@ class CdeNibrsIncident(models.NibrsIncident, QueryTraits):
 
         # Base Query
         query = CdeNibrsIncident.query
-        
+
         # Apply JOINS.
-        query = (query.join(CdeNibrsOffense).join(CdeNibrsLocationType)
-                 .outerjoin(CdeNibrsOffenseType)
-                 .outerjoin(CdeNibrsMonth).outerjoin(CdeRefAgency)
-                 .outerjoin(CdeRefCity).outerjoin(CdeRefState)
-                 .outerjoin(CdeNibrsOffender)
-                 .outerjoin(CdeNibrsWeapon)
-                 .outerjoin(CdeNibrsWeaponType)
-                 .outerjoin(models.NibrsAge)
-                 .outerjoin(CdeNibrsIncident.arrestee_age, CdeNibrsAge.age_id ==
-                           CdeNibrsIncident.arrestee_age.age_id)
-                 .outerjoin(CdeNibrsIncident.victim_age, CdeNibrsAge.age_id ==
-                           CdeNibrsIncident.victim_age.age_id)
-                 .outerjoin(CdeNibrsIncident.offender_age, CdeNibrsAge.age_id ==
-                           CdeNibrsIncident.offender_age.age_id)
-                 .outerjoin(models.RefRace)
-                 .outerjoin(CdeNibrsIncident.arrestee_race, CdeRefRace.race_id ==
-                           CdeNibrsIncident.arrestee_race.race_id)
-                 .outerjoin(CdeNibrsIncident.victim_race, CdeRefRace.race_id ==
-                           CdeNibrsIncident.victim_race.race_id)
-                 .outerjoin(CdeNibrsIncident.offender_race, CdeRefRace.race_id ==
-                           CdeNibrsIncident.offender_race.race_id)
-                 .outerjoin(CdeNibrsEthnicity)
-                 .outerjoin(CdeNibrsIncident.victim_ethnicity,CdeNibrsOffender.ethnicity_id ==
-                          CdeNibrsIncident.victim_ethnicity.ethnicity_id)
-                 .outerjoin(CdeNibrsIncident.offender_ethnicity,CdeNibrsOffender.ethnicity_id ==
-                          CdeNibrsIncident.offender_ethnicity.ethnicity_id)
-                 )
+        query = (
+            query.join(CdeNibrsOffense).join(CdeNibrsLocationType)
+            .outerjoin(CdeNibrsOffenseType)
+            .outerjoin(CdeNibrsMonth).outerjoin(CdeRefAgency)
+            .outerjoin(CdeRefCity).outerjoin(CdeRefState)
+            .outerjoin(CdeNibrsOffender).outerjoin(CdeNibrsWeapon)
+            .outerjoin(CdeNibrsWeaponType).outerjoin(models.NibrsAge)
+            .outerjoin(
+                CdeNibrsIncident.arrestee_age,
+                CdeNibrsAge.age_id == CdeNibrsIncident.arrestee_age.age_id)
+            .outerjoin(
+                CdeNibrsIncident.victim_age,
+                CdeNibrsAge.age_id == CdeNibrsIncident.victim_age.age_id)
+            .outerjoin(
+                CdeNibrsIncident.offender_age,
+                CdeNibrsAge.age_id == CdeNibrsIncident.offender_age.age_id)
+            .outerjoin(models.RefRace).outerjoin(
+                CdeNibrsIncident.arrestee_race,
+                CdeRefRace.race_id == CdeNibrsIncident.arrestee_race.race_id)
+            .outerjoin(
+                CdeNibrsIncident.victim_race,
+                CdeRefRace.race_id == CdeNibrsIncident.victim_race.race_id)
+            .outerjoin(
+                CdeNibrsIncident.offender_race,
+                CdeRefRace.race_id == CdeNibrsIncident.offender_race.race_id)
+            .outerjoin(CdeNibrsEthnicity).outerjoin(
+                CdeNibrsIncident.victim_ethnicity,
+                CdeNibrsOffender.ethnicity_id ==
+                CdeNibrsIncident.victim_ethnicity.ethnicity_id).outerjoin(
+                    CdeNibrsIncident.offender_ethnicity,
+                    CdeNibrsOffender.ethnicity_id ==
+                    CdeNibrsIncident.offender_ethnicity.ethnicity_id))
 
         # Apply field selections.
         query = query.with_entities(*fields)
 
         # Apply group by.
         query = CdeNibrsIncident.apply_group_by(query, by)
-        
+
         # Apply all filters
         query = CdeNibrsIncident.apply_filters(query, filters, args)
 
         return query
 
 
-
 class CdeRetaMonth(models.RetaMonth, QueryTraits):
-
 
     # Maps API filter to DB column name.
     @staticmethod
     def get_filter_map():
-        return {'state': CdeRefState.state_abbr.label('state'), 
-        'offense': CdeRetaOffense.offense_name,
-        'ori': CdeRefAgency.ori,
-        'subcategory': CdeRetaOffenseSubcat.offense_subcat_name,
-        'agency_name': CdeRefAgency.pub_agency_name, # Assuming Public Agency Name is the best one.
-        'city': CdeRefCity.city_name.label('city'),
-        'year': CdeRetaMonth.data_year,
-        'month': CdeRetaMonth.month_num }
-
+        return {
+            'state': CdeRefState.state_abbr.label('state'),
+            'offense': CdeRetaOffense.offense_name,
+            'ori': CdeRefAgency.ori,
+            'subcategory': CdeRetaOffenseSubcat.offense_subcat_name,
+            'agency_name':
+            CdeRefAgency.pub_agency_name,  # Assuming Public Agency Name is the best one.
+            'city': CdeRefCity.city_name.label('city'),
+            'year': CdeRetaMonth.data_year,
+            'month': CdeRetaMonth.month_num
+        }
 
     @staticmethod
     def get_reta_by_ori(ori=None, filters=None, by=None, args=None):
@@ -300,7 +329,8 @@ class TableFamily:
     def query(self):
         self._build_map()
         self.print_map()
-        qry = self.base_table.table.query
+        qry = self.base_query()
+
         for table in self.tables:
             if table.join is None:
                 qry = qry.join(table.table, isouter=table.outer)
@@ -365,6 +395,9 @@ class IncidentTableFamily(TableFamily):
     PREFIX_SEPARATOR = '.'
 
     base_table = JoinedTable(models.NibrsIncident)
+
+    def base_query(self):
+        return db.session.query(models.NibrsIncident)
 
     victim_race = aliased(models.RefRace)
     victim_age = aliased(models.NibrsAge)

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -519,14 +519,6 @@ class QueryWithAggregates(object):
         except FieldNameError as e:
             abort(400, e)
 
-    def paginate(self, page, per_page):
-        paginated = self.qry.limit(per_page).offset((page - 1) * per_page)
-        return Pagination(self.qry,
-                          page=page,
-                          per_page=per_page,
-                          total=self.qry.count(),
-                          items=paginated)
-
 
 class RetaQuery(QueryWithAggregates):
 

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -9,6 +9,7 @@ from crime_data.common.marshmallow_schemas import (ArgumentsSchema,
 
 from flask import make_response
 
+
 def _is_string(col):
     col0 = list(col.base_columns)[0]
     return issubclass(col0.type.python_type, str)
@@ -28,8 +29,10 @@ class IncidentsList(CdeResource):
         filters = self.filters(args)
         qry = self.tables.filtered(filters)
         if args['output'] == 'csv':
-            output = make_response(self.output_serialize(self.with_metadata(qry, args), self.schema))
-            output.headers["Content-Disposition"] = "attachment; filename=incidents.csv"
+            output = make_response(self.output_serialize(
+                self.with_metadata(qry, args), self.schema))
+            output.headers[
+                "Content-Disposition"] = "attachment; filename=incidents.csv"
             output.headers["Content-type"] = "text/csv"
             return output
         return self.with_metadata(qry, args)
@@ -61,4 +64,4 @@ class IncidentsCount(CdeResource):
             args['by'].lower())  # TODO: can post-process in schema?
         filters = list(self.filters(args))
         result = cdemodels.RetaQuery(by, filters)
-        return self.with_metadata(result, args)
+        return self.with_metadata(result.qry, args)


### PR DESCRIPTION
flask_sqlalchemy's built-in paginator has been failing badly (giving drastically low counts) for the complex queries beneath `/incidents/` and `/incidents/count/`.  Now counts match those produced with simple handwritten SQL.