### PR TITLE
csvwriter apparently throws silent exception, and expects a list...ho…

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -189,9 +189,9 @@ class CdeResource(Resource):
             for cs in to_csv:
                 if count == 0:
                     header = cs.keys()
-                    csvwriter.writerow(header)
+                    csvwriter.writerow(list(header))
                     count += 1
-                csvwriter.writerow(cs.values())
+                csvwriter.writerow(list(cs.values()))
 
         return si.getvalue().strip('\r\n')
 


### PR DESCRIPTION
Problem: StringIO.csvwriter expects a list (but only kind-of). It still works with non-listy sequenc-y objects #DynamicTypingProblems. However, it silently throws exception, and causes issues in non-debug environments. 

Fix: Added casting to lists to remedy this.

