### PR TITLE
Counties

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -124,6 +124,7 @@ class QueryTraits(object):
 
         return query
 
+
 class Fields(object):
     @staticmethod
     def get_db_column_names():
@@ -146,10 +147,10 @@ class Fields(object):
              'subcategory': 'subcategory_code'
             }
 
+
     @staticmethod
     def get_simplified_column_names():
         return {v: k for (k, v) in Fields.get_db_column_names().items()}
-
 
 
 class RoutingSQLAlchemy(SQLAlchemy):
@@ -322,11 +323,11 @@ class CdeResource(Resource):
 
     def as_csv_response(self, results, filename, args):
         """Returns the data as a CSV"""
-        output = make_response(
-            self.output_serialize(
-                self.with_metadata(results, args),
-                self.schema))
-        output.headers['Content-Disposition'] = 'attachment; filename={0}.csv'.format(filename)
+        output = make_response(self.output_serialize(
+            self.with_metadata(results, args), self.schema))
+        output.headers[
+            'Content-Disposition'] = 'attachment; filename={0}.csv'.format(
+                filename)
         output.headers['Content-type'] = 'text/csv'
         return output
 

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -133,6 +133,7 @@ class Fields(object):
              'agency_name': 'ucr_agency_name',
              'state': 'state_abbr',
              'city': 'city_name',
+             'county': 'county_name',
              'tribe': 'tribe_name',
              'offense': 'offense_name',
              'offense_subcat': 'offense_subcat_name',

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -162,6 +162,7 @@ class RefCitySchema(ma.ModelSchema):
 
 #    state = ma.Nested(RefStateSchema)
 
+
 class RefContinentSchema(ma.ModelSchema):
     class Meta:
         model = models.RefContinent
@@ -172,7 +173,7 @@ class RefContinentSchema(ma.ModelSchema):
 class RefCountySchema(ma.ModelSchema):
     class Meta:
         model = models.RefCounty
-        exclude = ('county_id', 'state', )
+        exclude = ('county_id', 'state', 'agencies', 'agency_associations', )
         ordered = True
 
     state = ma.Nested(RefStateSchema)
@@ -240,14 +241,12 @@ class RefTribeSchema(ma.ModelSchema):
         exclude = ('tribe_id', )
 
 
-class RefCountySchema(ma.ModelSchema):
-    class Meta:
-        model = models.RefCounty
-
-
 class RefAgencyCountySchema(ma.ModelSchema):
     class Meta:
         model = models.RefAgencyCounty
+        exclude = ('change_timestamp', 'change_user', 'agency', )
+
+    county = ma.Nested(RefCountySchema)
 
 
 class RefUniversitySchema(ma.ModelSchema):
@@ -259,6 +258,7 @@ class RefUniversitySchema(ma.ModelSchema):
 class RefAgencySchema(ma.ModelSchema, ArgumentsSchema):
     class Meta:
         model = models.RefAgency
+        exclude = ('county_associations', )
 
     city = ma.Nested(RefCitySchema)
     state = ma.Nested(RefStateSchema)
@@ -268,7 +268,7 @@ class RefAgencySchema(ma.ModelSchema, ArgumentsSchema):
     population_family = ma.Nested(RefPopulationFamilySchema)
     submitting_agency = ma.Nested(RefSubmittingAgencySchema)
     tribe = ma.Nested(RefTribeSchema)
-    counties = ma.Nested(RefAgencyCountySchema, many=True)
+    counties = ma.Nested(RefCountySchema, many=True)
 
 
 class RetaMonthSchema(ma.ModelSchema):
@@ -295,7 +295,7 @@ class AsrAgeRangeSchema(ma.ModelSchema):
         exclude = ('age_range_id', )
         ordered = True
 
-        
+
 class AsrEthnicitySchema(ma.ModelSchema):
     class Meta:
         model = models.AsrEthnicity
@@ -354,7 +354,7 @@ class NibrsPropDescTypeSchema(ma.ModelSchema):
         model = models.NibrsPropDescType
         exclude = ('prop_desc_id', )
 
-        
+
 class NibrsPropLossTypeSchema(ma.ModelSchema):
     class Meta:
         model = models.NibrsPropLossType
@@ -514,7 +514,7 @@ class NibrsAssignmentTypeSchema(ma.ModelSchema):
         exclude = ('assignment_type_id', )
         ordered = True
 
-    
+
 class NibrsBiasListSchema(ma.ModelSchema):
     class Meta:
         model = models.NibrsBiasList

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -240,12 +240,22 @@ class RefTribeSchema(ma.ModelSchema):
         exclude = ('tribe_id', )
 
 
+class RefCountySchema(ma.ModelSchema):
+    class Meta:
+        model = models.RefCounty
+
+
+class RefAgencyCountySchema(ma.ModelSchema):
+    class Meta:
+        model = models.RefAgencyCounty
+
+
 class RefUniversitySchema(ma.ModelSchema):
     class Meta:
         model = models.RefUniversity
         exclude = ('university_id', )
 
-        
+
 class RefAgencySchema(ma.ModelSchema, ArgumentsSchema):
     class Meta:
         model = models.RefAgency
@@ -258,6 +268,7 @@ class RefAgencySchema(ma.ModelSchema, ArgumentsSchema):
     population_family = ma.Nested(RefPopulationFamilySchema)
     submitting_agency = ma.Nested(RefSubmittingAgencySchema)
     tribe = ma.Nested(RefTribeSchema)
+    counties = ma.Nested(RefAgencyCountySchema, many=True)
 
 
 class RetaMonthSchema(ma.ModelSchema):

--- a/crime_data/common/models.py
+++ b/crime_data/common/models.py
@@ -15,6 +15,7 @@ db = SQLAlchemy()
 #Base = declarative_base()
 #metadata = Base.metadata
 
+
 class RefRace(db.Model):
     __tablename__ = 'ref_race'
 
@@ -25,6 +26,7 @@ class RefRace(db.Model):
     start_year = db.Column(db.SmallInteger)
     end_year = db.Column(db.SmallInteger)
     notes = db.Column(db.String(1000))
+
 
 class ArsonMonth(db.Model):
     __tablename__ = 'arson_month'
@@ -45,12 +47,12 @@ class ArsonMonth(db.Model):
     update_flag = db.Column(db.String(1))
     did = db.Column(db.BigInteger)
     ff_line_number = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -60,11 +62,10 @@ class ArsonMonthBySubcat(db.Model):
     __table_args__ = (
         db.UniqueConstraint('arson_month_id', 'subcategory_id'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('arson_month_by_subcat_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('arson_month_by_subcat_id_seq'::regclass)"))
     reported_count = db.Column(db.Integer)
     reported_status = db.Column(db.SmallInteger)
     unfounded_count = db.Column(db.Integer)
@@ -79,22 +80,19 @@ class ArsonMonthBySubcat(db.Model):
     uninhabited_status = db.Column(db.SmallInteger)
     est_damage_value = db.Column(db.BigInteger)
     est_damage_value_status = db.Column(db.SmallInteger)
-    arson_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'arson_month.arson_month_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    subcategory_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'arson_subcategory.subcategory_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    arson_month_id = db.Column(db.Integer,
+                               db.ForeignKey('arson_month.arson_month_id',
+                                             deferrable=True,
+                                             initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
+    subcategory_id = db.Column(db.Integer,
+                               db.ForeignKey(
+                                   'arson_subcategory.subcategory_id',
+                                   deferrable=True,
+                                   initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
 
     arson_month = db.relationship('ArsonMonth')
     subcategory = db.relationship('ArsonSubcategory')
@@ -107,14 +105,13 @@ class ArsonSubcategory(db.Model):
     subcategory_name = db.Column(db.String(100))
     subcategory_code = db.Column(db.String(20), unique=True)
     subcat_xml_path = db.Column(db.String(4000))
-    subclass_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'arson_subclassification.subclass_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    subclass_id = db.Column(db.Integer,
+                            db.ForeignKey(
+                                'arson_subclassification.subclass_id',
+                                deferrable=True,
+                                initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
 
     subclass = db.relationship('ArsonSubclassification')
 
@@ -155,28 +152,25 @@ class AsrAgeSexSubcat(db.Model):
     prepared_date = db.Column(db.DateTime(True))
     report_date = db.Column(db.DateTime(True))
     ff_line_number = db.Column(db.BigInteger)
-    age_range_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_age_range.age_range_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    asr_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_month.asr_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_subcat_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_offense_subcat.offense_subcat_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    age_range_id = db.Column(db.Integer,
+                             db.ForeignKey('asr_age_range.age_range_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    asr_month_id = db.Column(db.Integer,
+                             db.ForeignKey('asr_month.asr_month_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    offense_subcat_id = db.Column(db.Integer,
+                                  db.ForeignKey(
+                                      'asr_offense_subcat.offense_subcat_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                                  nullable=False,
+                                  index=True)
 
     age_range = db.relationship('AsrAgeRange')
     asr_month = db.relationship('AsrMonth')
@@ -197,39 +191,35 @@ class AsrEthnicityOffense(db.Model):
     __table_args__ = (db.UniqueConstraint('asr_month_id', 'offense_subcat_id',
                                           'ethnicity_id', 'juvenile_flag'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('asr_ethnicity_offense_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('asr_ethnicity_offense_id_seq'::regclass)"))
     juvenile_flag = db.Column(db.String(1), nullable=False)
     arrest_count = db.Column(db.Integer)
     arrest_status = db.Column(db.SmallInteger)
     prepared_date = db.Column(db.DateTime(True))
     report_date = db.Column(db.DateTime(True))
     ff_line_number = db.Column(db.BigInteger)
-    asr_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_month.asr_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_subcat_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_offense_subcat.offense_subcat_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    asr_month_id = db.Column(db.Integer,
+                             db.ForeignKey('asr_month.asr_month_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('asr_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    offense_subcat_id = db.Column(db.Integer,
+                                  db.ForeignKey(
+                                      'asr_offense_subcat.offense_subcat_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                                  nullable=False,
+                                  index=True)
 
     asr_month = db.relationship('AsrMonth')
     ethnicity = db.relationship('AsrEthnicity')
@@ -252,12 +242,12 @@ class AsrMonth(db.Model):
     ddocname = db.Column(db.String(100))
     did = db.Column(db.BigInteger)
     data_home = db.Column(db.String(1), nullable=False)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -265,11 +255,11 @@ class AsrMonth(db.Model):
 class AsrJuvenileDisposition(AsrMonth):
     __tablename__ = 'asr_juvenile_disposition'
 
-    asr_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_month.asr_month_id', deferrable=True, initially='DEFERRED'),
-        primary_key=True)
+    asr_month_id = db.Column(db.Integer,
+                             db.ForeignKey('asr_month.asr_month_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             primary_key=True)
     report_date = db.Column(db.DateTime(True))
     prepared_date = db.Column(db.DateTime(True))
     handled_within_dept = db.Column(db.Integer)
@@ -287,14 +277,13 @@ class AsrOffense(db.Model):
     offense_name = db.Column(db.String(100))
     offense_code = db.Column(db.String(20), unique=True)
     total_flag = db.Column(db.String(1))
-    offense_cat_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_offense_category.offense_cat_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_cat_id = db.Column(db.Integer,
+                               db.ForeignKey(
+                                   'asr_offense_category.offense_cat_id',
+                                   deferrable=True,
+                                   initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
 
     offense_cat = db.relationship('AsrOffenseCategory')
 
@@ -317,12 +306,12 @@ class AsrOffenseSubcat(db.Model):
     master_offense_code = db.Column(db.SmallInteger)
     total_flag = db.Column(db.String(1))
     adult_juv_flag = db.Column(db.String(1))
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('asr_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
 
     offense = db.relationship('AsrOffense')
 
@@ -332,11 +321,10 @@ class AsrRaceOffenseSubcat(db.Model):
     __table_args__ = (db.UniqueConstraint('asr_month_id', 'offense_subcat_id',
                                           'race_id', 'juvenile_flag'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('asr_race_offense_subcat_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('asr_race_offense_subcat_id_seq'::regclass)"))
     juvenile_flag = db.Column(db.String(1), nullable=False)
     arrest_count = db.Column(db.Integer)
     arrest_status = db.Column(db.SmallInteger)
@@ -344,26 +332,25 @@ class AsrRaceOffenseSubcat(db.Model):
     prepared_date = db.Column(db.DateTime(True))
     report_date = db.Column(db.DateTime(True))
     ff_line_number = db.Column(db.BigInteger)
-    asr_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_month.asr_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_subcat_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'asr_offense_subcat.offense_subcat_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    asr_month_id = db.Column(db.Integer,
+                             db.ForeignKey('asr_month.asr_month_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    offense_subcat_id = db.Column(db.Integer,
+                                  db.ForeignKey(
+                                      'asr_offense_subcat.offense_subcat_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                                  nullable=False,
+                                  index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        nullable=False,
+                        index=True)
 
     asr_month = db.relationship('AsrMonth')
     offense_subcat = db.relationship('AsrOffenseSubcat')
@@ -385,24 +372,22 @@ class CtArrestee(db.Model):
     arrestee_id = db.Column(db.BigInteger, primary_key=True)
     age = db.Column(db.SmallInteger)
     sex_code = db.Column(db.String(1))
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ct_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('ct_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
 
     ethnicity = db.relationship('NibrsEthnicity')
     incident = db.relationship('CtIncident')
@@ -430,18 +415,18 @@ class CtIncident(db.Model):
     unknown_offender = db.Column(db.String(1))
     did = db.Column(db.BigInteger)
     nibrs_incident_id = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    ct_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ct_month.ct_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
+    ct_month_id = db.Column(db.Integer,
+                            db.ForeignKey('ct_month.ct_month_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
 
     agency = db.relationship('RefAgency')
     ct_month = db.relationship('CtMonth')
@@ -461,12 +446,12 @@ class CtMonth(db.Model):
     did = db.Column(db.BigInteger)
     data_home = db.Column(db.String(1), nullable=False)
     orig_format = db.Column(db.String(1))
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -477,24 +462,22 @@ class CtOffender(db.Model):
     offender_id = db.Column(db.BigInteger, primary_key=True)
     age = db.Column(db.SmallInteger)
     sex_code = db.Column(db.String(1))
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ct_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('ct_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
 
     ethnicity = db.relationship('NibrsEthnicity')
     incident = db.relationship('CtIncident')
@@ -506,28 +489,25 @@ class CtOffense(db.Model):
 
     offense_id = db.Column(db.BigInteger, primary_key=True)
     ct_offense_flag = db.Column(db.String(1))
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ct_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    location_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_location_type.location_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offense_type.offense_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('ct_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    location_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_location_type.location_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    offense_type_id = db.Column(db.Integer,
+                                db.ForeignKey(
+                                    'nibrs_offense_type.offense_type_id',
+                                    deferrable=True,
+                                    initially='DEFERRED'),
+                                nullable=False,
+                                index=True)
 
     incident = db.relationship('CtIncident')
     location = db.relationship('NibrsLocationType')
@@ -542,20 +522,18 @@ class CtProperty(db.Model):
     recovered_flag = db.Column(db.String(1))
     date_recovered = db.Column(db.DateTime(True))
     recovered_value = db.Column(db.BigInteger)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ct_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    prop_desc_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_prop_desc_type.prop_desc_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('ct_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    prop_desc_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_prop_desc_type.prop_desc_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
 
     incident = db.relationship('CtIncident')
     prop_desc = db.relationship('NibrsPropDescType')
@@ -569,20 +547,19 @@ class CtVictim(db.Model):
         db.Integer,
         primary_key=True,
         server_default=text("nextval('ct_victim_id_seq'::regclass)"))
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ct_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    victim_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_victim_type.victim_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('ct_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    victim_type_id = db.Column(db.Integer,
+                               db.ForeignKey(
+                                   'nibrs_victim_type.victim_type_id',
+                                   deferrable=True,
+                                   initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
 
     incident = db.relationship('CtIncident')
     victim_type = db.relationship('NibrsVictimType')
@@ -592,20 +569,18 @@ class CtWeapon(db.Model):
     __tablename__ = 'ct_weapon'
 
     ct_weapon_id = db.Column(db.BigInteger, primary_key=True)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ct_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    weapon_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_weapon_type.weapon_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('ct_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    weapon_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_weapon_type.weapon_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     incident = db.relationship('CtIncident')
     weapon = db.relationship('NibrsWeaponType')
@@ -619,18 +594,18 @@ class HcBiasMotivation(db.Model):
         db.Integer,
         primary_key=True,
         server_default=text("nextval('hc_bias_motivation_id_seq'::regclass)"))
-    bias_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_bias_list.bias_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'hc_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    bias_id = db.Column(db.Integer,
+                        db.ForeignKey('nibrs_bias_list.bias_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        nullable=False,
+                        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('hc_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
 
     bias = db.relationship('NibrsBiasList')
     offense = db.relationship('HcOffense')
@@ -659,30 +634,29 @@ class HcIncident(db.Model):
     orig_format = db.Column(db.String(1))
     did = db.Column(db.BigInteger)
     nibrs_incident_id = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    hc_quarter_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'hc_quarter.hc_quarter_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
+    hc_quarter_id = db.Column(db.Integer,
+                              db.ForeignKey('hc_quarter.hc_quarter_id',
+                                            deferrable=True,
+                                            initially='DEFERRED'),
+                              nullable=False,
+                              index=True)
     offender_ethnicity_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    offender_race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    offender_race_id = db.Column(db.Integer,
+                                 db.ForeignKey('ref_race.race_id',
+                                               deferrable=True,
+                                               initially='DEFERRED'),
+                                 index=True)
 
     agency = db.relationship('RefAgency')
     hc_quarter = db.relationship('HcQuarter')
@@ -696,25 +670,22 @@ class HcOffense(db.Model):
     offense_id = db.Column(db.BigInteger, primary_key=True)
     victim_count = db.Column(db.SmallInteger)
     nibrs_offense_id = db.Column(db.BigInteger)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'hc_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    location_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_location_type.location_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('hc_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    location_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_location_type.location_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            index=True)
     offense_type_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_offense_type.offense_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_offense_type.offense_type_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
 
     incident = db.relationship('HcIncident')
@@ -738,12 +709,12 @@ class HcQuarter(db.Model):
     ddocname = db.Column(db.String(100))
     did = db.Column(db.BigInteger)
     data_home = db.Column(db.String(1), nullable=False)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -756,20 +727,19 @@ class HcVictim(db.Model):
         db.Integer,
         primary_key=True,
         server_default=text("nextval('hc_victim_id_seq'::regclass)"))
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'hc_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    victim_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_victim_type.victim_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('hc_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
+    victim_type_id = db.Column(db.Integer,
+                               db.ForeignKey(
+                                   'nibrs_victim_type.victim_type_id',
+                                   deferrable=True,
+                                   initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
 
     offense = db.relationship('HcOffense')
     victim_type = db.relationship('NibrsVictimType')
@@ -800,12 +770,12 @@ class HtMonth(db.Model):
     reported_flag = db.Column(db.String(1))
     did = db.Column(db.BigInteger)
     ff_line_number = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -814,11 +784,10 @@ class HtMonthOffenseSubcat(db.Model):
     __tablename__ = 'ht_month_offense_subcat'
     __table_args__ = (UniqueConstraint('offense_subcat_id', 'ht_month_id'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('ht_month_offense_subcat_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('ht_month_offense_subcat_id_seq'::regclass)"))
     reported_count = db.Column(db.Integer)
     reported_status = db.Column(db.SmallInteger)
     unfounded_count = db.Column(db.Integer)
@@ -829,20 +798,19 @@ class HtMonthOffenseSubcat(db.Model):
     cleared_status = db.Column(db.SmallInteger)
     juvenile_cleared_count = db.Column(db.Integer)
     juvenile_cleared_status = db.Column(db.SmallInteger)
-    ht_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ht_month.ht_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_subcat_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'reta_offense_subcat.offense_subcat_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    ht_month_id = db.Column(db.Integer,
+                            db.ForeignKey('ht_month.ht_month_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    offense_subcat_id = db.Column(db.Integer,
+                                  db.ForeignKey(
+                                      'reta_offense_subcat.offense_subcat_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                                  nullable=False,
+                                  index=True)
 
     ht_month = db.relationship('HtMonth')
     offense_subcat = db.relationship('RetaOffenseSubcat')
@@ -888,57 +856,53 @@ class NibrsArrestee(db.Model):
     ff_line_number = db.Column(db.BigInteger)
     age_range_low_num = db.Column(db.SmallInteger)
     age_range_high_num = db.Column(db.SmallInteger)
-    age_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_age.age_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    age_id = db.Column(db.Integer,
+                       db.ForeignKey('nibrs_age.age_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       nullable=False,
+                       index=True)
     arrest_type_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_arrest_type.arrest_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_arrest_type.arrest_type_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_incident.incident_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offense_type.offense_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    offense_type_id = db.Column(db.Integer,
+                                db.ForeignKey(
+                                    'nibrs_offense_type.offense_type_id',
+                                    deferrable=True,
+                                    initially='DEFERRED'),
+                                nullable=False,
+                                index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        nullable=False,
+                        index=True)
 
     age = db.relationship('NibrsAge', backref='arrestees', lazy=False)
-    arrest_type = db.relationship(
-        'NibrsArrestType', lazy=False, backref='arrestees')
-    ethnicity = db.relationship(
-        'NibrsEthnicity', lazy=False, backref='arrestees')
-    incident = db.relationship(
-        'NibrsIncident', backref=backref(
-            'arrestees', lazy=False))
+    arrest_type = db.relationship('NibrsArrestType',
+                                  lazy=False,
+                                  backref='arrestees')
+    ethnicity = db.relationship('NibrsEthnicity',
+                                lazy=False,
+                                backref='arrestees')
+    incident = db.relationship('NibrsIncident',
+                               backref=backref('arrestees',
+                                               lazy=False))
     offense_type = db.relationship('NibrsOffenseType', backref='arrestees')
     race = db.relationship('RefRace', lazy=False, backref='arrestees')
 
@@ -947,22 +911,18 @@ class NibrsArresteeWeapon(db.Model):
     __tablename__ = 'nibrs_arrestee_weapon'
 
     nibrs_arrestee_weapon_id = db.Column(db.BigInteger, primary_key=True)
-    arrestee_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_arrestee.arrestee_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    weapon_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_weapon_type.weapon_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    arrestee_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_arrestee.arrestee_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    weapon_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_weapon_type.weapon_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     arrestee = db.relationship('NibrsArrestee')
     weapon = db.relationship('NibrsWeaponType')
@@ -988,23 +948,22 @@ class NibrsBiasMotivation(db.Model):
     __tablename__ = 'nibrs_bias_motivation'
     __table_args__ = (UniqueConstraint('bias_id', 'offense_id'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('nibrs_bias_motivation_id_seq'::regclass)"))
-    bias_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_bias_list.bias_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('nibrs_bias_motivation_id_seq'::regclass)"))
+    bias_id = db.Column(db.Integer,
+                        db.ForeignKey('nibrs_bias_list.bias_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        nullable=False,
+                        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('nibrs_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
 
     bias = db.relationship('NibrsBiasList')
     offense = db.relationship('NibrsOffense')
@@ -1047,7 +1006,8 @@ class NibrsCriminalAct(db.Model):
                            nullable=False,
                            index=True)
 
-    criminal_act = db.relationship('NibrsCriminalActType', backref='criminal_acts')
+    criminal_act = db.relationship('NibrsCriminalActType',
+                                   backref='criminal_acts')
     offense = db.relationship('NibrsOffense', backref='criminal_acts')
 
 
@@ -1122,37 +1082,33 @@ class NibrsGrpbArrest(db.Model):
     did = db.Column(db.BigInteger)
     age_range_low_num = db.Column(db.SmallInteger)
     age_range_high_num = db.Column(db.SmallInteger)
-    age_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_age.age_id', deferrable=True, initially='DEFERRED'),
-        index=True)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    nibrs_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_month.nibrs_month_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    age_id = db.Column(db.Integer,
+                       db.ForeignKey('nibrs_age.age_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    nibrs_month_id = db.Column(db.Integer,
+                               db.ForeignKey('nibrs_month.nibrs_month_id',
+                                             deferrable=True,
+                                             initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
 
     age = db.relationship('NibrsAge')
     agency = db.relationship('RefAgency')
@@ -1165,22 +1121,19 @@ class NibrsGrpbArrestWeapon(db.Model):
     __tablename__ = 'nibrs_grpb_arrest_weapon'
 
     nibrs_grpb_arrest_weapon_id = db.Column(db.BigInteger, primary_key=True)
-    grpb_arrest_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_grpb_arrest.grpb_arrest_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    weapon_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_weapon_type.weapon_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    grpb_arrest_id = db.Column(db.Integer,
+                               db.ForeignKey(
+                                   'nibrs_grpb_arrest.grpb_arrest_id',
+                                   deferrable=True,
+                                   initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
+    weapon_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_weapon_type.weapon_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     grpb_arrest = db.relationship('NibrsGrpbArrest')
     weapon = db.relationship('NibrsWeaponType')
@@ -1203,28 +1156,25 @@ class NibrsIncident(db.Model):
     orig_format = db.Column(db.String(1))
     ff_line_number = db.Column(db.BigInteger)
     did = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    cleared_except_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_cleared_except.cleared_except_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    nibrs_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_month.nibrs_month_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
+    cleared_except_id = db.Column(db.Integer,
+                                  db.ForeignKey(
+                                      'nibrs_cleared_except.cleared_except_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                                  nullable=False,
+                                  index=True)
+    nibrs_month_id = db.Column(db.Integer,
+                               db.ForeignKey('nibrs_month.nibrs_month_id',
+                                             deferrable=True,
+                                             initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
 
     agency = db.relationship('RefAgency')
     cleared_except = db.relationship('NibrsClearedExcept', lazy=False)
@@ -1272,12 +1222,12 @@ class NibrsMonth(db.Model):
     data_home = db.Column(db.String(1))
     ddocname = db.Column(db.String(50))
     did = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -1292,37 +1242,33 @@ class NibrsOffender(db.Model):
     ff_line_number = db.Column(db.BigInteger)
     age_range_low_num = db.Column(db.SmallInteger)
     age_range_high_num = db.Column(db.SmallInteger)
-    age_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_age.age_id', deferrable=True, initially='DEFERRED'),
-        index=True)
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_incident.incident_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    age_id = db.Column(db.Integer,
+                       db.ForeignKey('nibrs_age.age_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
 
     age = db.relationship('NibrsAge', backref='offenders', lazy=False)
     ethnicity = db.relationship('NibrsEthnicity', backref='offenders')
-    incident = db.relationship(
-        'NibrsIncident', backref=backref(
-            'offenders', lazy=False))
+    incident = db.relationship('NibrsIncident',
+                               backref=backref('offenders',
+                                               lazy=False))
     race = db.relationship('RefRace', lazy=False, backref='offenders')
 
 
@@ -1334,38 +1280,35 @@ class NibrsOffense(db.Model):
     num_premises_entered = db.Column(db.SmallInteger)
     method_entry_code = db.Column(db.String(1))
     ff_line_number = db.Column(db.BigInteger)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_incident.incident_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    location_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_location_type.location_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offense_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offense_type.offense_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    location_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_location_type.location_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    offense_type_id = db.Column(db.Integer,
+                                db.ForeignKey(
+                                    'nibrs_offense_type.offense_type_id',
+                                    deferrable=True,
+                                    initially='DEFERRED'),
+                                nullable=False,
+                                index=True)
 
-    incident = db.relationship(
-        'NibrsIncident', backref=backref(
-            'offenses', lazy=False))
-    location = db.relationship(
-        'NibrsLocationType', lazy=False, backref='offenses')
-    offense_type = db.relationship(
-        'NibrsOffenseType', lazy=False, backref='offenses')
+    incident = db.relationship('NibrsIncident',
+                               backref=backref('offenses',
+                                               lazy=False))
+    location = db.relationship('NibrsLocationType',
+                               lazy=False,
+                               backref='offenses')
+    offense_type = db.relationship('NibrsOffenseType',
+                                   lazy=False,
+                                   backref='offenses')
 
 
 class NibrsOffenseType(db.Model):
@@ -1403,28 +1346,25 @@ class NibrsProperty(db.Model):
     stolen_count = db.Column(db.SmallInteger)
     recovered_count = db.Column(db.SmallInteger)
     ff_line_number = db.Column(db.BigInteger)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_incident.incident_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    prop_loss_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_prop_loss_type.prop_loss_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    prop_loss_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_prop_loss_type.prop_loss_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
 
-    incident = db.relationship(
-        'NibrsIncident', backref=backref(
-            'property', lazy=False))
-    prop_loss = db.relationship(
-        'NibrsPropLossType', lazy=False, backref='property')
+    incident = db.relationship('NibrsIncident',
+                               backref=backref('property',
+                                               lazy=False))
+    prop_loss = db.relationship('NibrsPropLossType',
+                                lazy=False,
+                                backref='property')
 
 
 class NibrsPropertyDesc(db.Model):
@@ -1433,22 +1373,18 @@ class NibrsPropertyDesc(db.Model):
     property_value = db.Column(db.BigInteger)
     date_recovered = db.Column(db.DateTime(True))
     nibrs_prop_desc_id = db.Column(db.BigInteger, primary_key=True)
-    prop_desc_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_prop_desc_type.prop_desc_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    property_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_property.property_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    prop_desc_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_prop_desc_type.prop_desc_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    property_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_property.property_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
 
     prop_desc = db.relationship('NibrsPropDescType')
     property = db.relationship('NibrsProperty')
@@ -1465,11 +1401,10 @@ class NibrsRelationship(db.Model):
 class NibrsSumMonthTemp(db.Model):
     __tablename__ = 'nibrs_sum_month_temp'
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('nibrs_sum_month_temp_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('nibrs_sum_month_temp_id_seq'::regclass)"))
     nibrs_month_id = db.Column(db.BigInteger)
     agency_id = db.Column(db.BigInteger)
     month_num = db.Column(db.SmallInteger)
@@ -1497,20 +1432,19 @@ class NibrsSuspectUsing(db.Model):
         db.Integer,
         primary_key=True,
         server_default=text("nextval('nibrs_suspect_using_id_seq'::regclass)"))
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    suspect_using_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_using_list.suspect_using_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('nibrs_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
+    suspect_using_id = db.Column(db.Integer,
+                                 db.ForeignKey(
+                                     'nibrs_using_list.suspect_using_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                                 nullable=False,
+                                 index=True)
 
     offense = db.relationship('NibrsOffense')
     suspect_using = db.relationship('NibrsUsingList')
@@ -1523,25 +1457,21 @@ class NibrsSuspectedDrug(db.Model):
     nibrs_suspected_drug_id = db.Column(db.BigInteger, primary_key=True)
     drug_measure_type_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_drug_measure_type.drug_measure_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_drug_measure_type.drug_measure_type_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    property_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_property.property_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    property_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_property.property_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
     suspected_drug_type_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_suspected_drug_type.suspected_drug_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_suspected_drug_type.suspected_drug_type_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         nullable=False,
         index=True)
 
@@ -1581,62 +1511,56 @@ class NibrsVictim(db.Model):
     age_range_high_num = db.Column(db.SmallInteger)
     activity_type_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_activity_type.activity_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_activity_type.activity_type_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    age_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_age.age_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    age_id = db.Column(db.Integer,
+                       db.ForeignKey('nibrs_age.age_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       index=True)
     assignment_type_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_assignment_type.assignment_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_assignment_type.assignment_type_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_incident.incident_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
-    victim_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_victim_type.victim_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
+    victim_type_id = db.Column(db.Integer,
+                               db.ForeignKey(
+                                   'nibrs_victim_type.victim_type_id',
+                                   deferrable=True,
+                                   initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
 
     activity_type = db.relationship('NibrsActivityType', backref='victims')
     age = db.relationship('NibrsAge', backref='victims', lazy=False)
     assignment_type = db.relationship('NibrsAssignmentType', backref='victims')
     ethnicity = db.relationship('NibrsEthnicity', backref='victims')
-    incident = db.relationship(
-        'NibrsIncident', backref=backref(
-            'victims', lazy=False))
+    incident = db.relationship('NibrsIncident',
+                               backref=backref('victims',
+                                               lazy=False))
     race = db.relationship('RefRace', lazy=False, backref='victims')
-    victim_type = db.relationship(
-        'NibrsVictimType', lazy=False, backref='victims')
+    victim_type = db.relationship('NibrsVictimType',
+                                  lazy=False,
+                                  backref='victims')
 
 
 class NibrsVictimCircumstance(db.Model):
@@ -1648,27 +1572,25 @@ class NibrsVictimCircumstance(db.Model):
         primary_key=True,
         server_default=text(
             "nextval('nibrs_victim_circumstances_id_seq'::regclass)"))
-    circumstances_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_circumstances.circumstances_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    circumstances_id = db.Column(db.Integer,
+                                 db.ForeignKey(
+                                     'nibrs_circumstances.circumstances_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                                 nullable=False,
+                                 index=True)
     justifiable_force_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'nibrs_justifiable_force.justifiable_force_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('nibrs_justifiable_force.justifiable_force_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    victim_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_victim.victim_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    victim_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_victim.victim_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     circumstances = db.relationship('NibrsCircumstance')
     justifiable_force = db.relationship('NibrsJustifiableForce')
@@ -1706,31 +1628,29 @@ class NibrsVictimOffenderRel(db.Model):
     __tablename__ = 'nibrs_victim_offender_rel'
 
     nibrs_victim_offender_id = db.Column(db.BigInteger, primary_key=True)
-    offender_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offender.offender_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    relationship_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_relationship.relationship_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    victim_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_victim.victim_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offender_id = db.Column(db.Integer,
+                            db.ForeignKey('nibrs_offender.offender_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    relationship_id = db.Column(db.Integer,
+                                db.ForeignKey(
+                                    'nibrs_relationship.relationship_id',
+                                    deferrable=True,
+                                    initially='DEFERRED'),
+                                nullable=False,
+                                index=True)
+    victim_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_victim.victim_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     offender = db.relationship('NibrsOffender', backref="relationships")
-    relationship_ = db.relationship('NibrsRelationship', backref="relationships")
+    relationship_ = db.relationship('NibrsRelationship',
+                                    backref="relationships")
     victim = db.relationship('NibrsVictim', backref="relationships")
 
 
@@ -1738,23 +1658,22 @@ class NibrsVictimOffense(db.Model):
     __tablename__ = 'nibrs_victim_offense'
     __table_args__ = (UniqueConstraint('victim_id', 'offense_id'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('nibrs_victim_offense_id_seq'::regclass)"))
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    victim_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_victim.victim_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('nibrs_victim_offense_id_seq'::regclass)"))
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('nibrs_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
+    victim_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_victim.victim_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     offense = db.relationship('NibrsOffense')
     victim = db.relationship('NibrsVictim')
@@ -1772,24 +1691,21 @@ class NibrsWeapon(db.Model):
     __tablename__ = 'nibrs_weapon'
 
     nibrs_weapon_id = db.Column(db.BigInteger, primary_key=True)
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    weapon_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_weapon_type.weapon_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('nibrs_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
+    weapon_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_weapon_type.weapon_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     weapon = db.relationship('NibrsWeaponType', backref='weapons')
     offense = db.relationship('NibrsOffense', backref='weapons')
-
 
 
 class NibrsWeaponType(db.Model):
@@ -1807,97 +1723,6 @@ class OffenseClassification(db.Model):
     classification_id = db.Column(db.SmallInteger, primary_key=True)
     classification_name = db.Column(db.String(50))
     class_sort_order = db.Column(db.SmallInteger)
-
-
-class RefAgency(db.Model):
-    __tablename__ = 'ref_agency'
-
-    agency_id = db.Column(db.BigInteger, primary_key=True)
-    ori = db.Column(db.String(9), nullable=False, unique=True)
-    legacy_ori = db.Column(db.String(9), nullable=False)
-    ucr_agency_name = db.Column(db.String(100))
-    ncic_agency_name = db.Column(db.String(100))
-    pub_agency_name = db.Column(db.String(100))
-    special_mailing_group = db.Column(db.String(1))
-    special_mailing_address = db.Column(db.String(1))
-    agency_status = db.Column(db.String(1), nullable=False)
-    judicial_dist_code = db.Column(db.String(4))
-    fid_code = db.Column(db.String(2))
-    added_date = db.Column(db.DateTime(True))
-    change_timestamp = db.Column(db.DateTime(True))
-    change_user = db.Column(db.String(100))
-    legacy_notify_agency = db.Column(db.String(1))
-    dormant_year = db.Column(db.SmallInteger)
-    agency_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency_type.agency_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    campus_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_university_campus.campus_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    city_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_city.city_id', deferrable=True, initially='DEFERRED'),
-        index=True)
-    department_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_department.department_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    field_office_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_field_office.field_office_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    population_family_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_population_family.population_family_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    state_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_state.state_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    submitting_agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_submitting_agency.agency_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    tribe_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_tribe.tribe_id', deferrable=True, initially='DEFERRED'),
-        index=True)
-
-    agency_type = db.relationship('RefAgencyType', lazy=False)
-    campus = db.relationship('RefUniversityCampu')
-    city = db.relationship('RefCity', lazy=False)
-    department = db.relationship('RefDepartment', lazy=False)
-    field_office = db.relationship('RefFieldOffice', lazy=False)
-    population_family = db.relationship('RefPopulationFamily', lazy=False)
-    state = db.relationship('RefState', lazy=False)
-    submitting_agency = db.relationship('RefSubmittingAgency', lazy=False)
-    tribe = db.relationship('RefTribe')
 
 
 class RefAgencyCounty(db.Model):
@@ -1919,66 +1744,152 @@ class RefAgencyCounty(db.Model):
                                         deferrable=True,
                                         initially='DEFERRED'),
                           nullable=False,
-                          index=True, primary_key=True)
+                          index=True,
+                          primary_key=True)
     county_id = db.Column(db.Integer,
                           db.ForeignKey('ref_county.county_id',
                                         deferrable=True,
                                         initially='DEFERRED'),
                           nullable=False,
-                          index=True, primary_key=True)
+                          index=True,
+                          primary_key=True)
     metro_div_id = db.Column(db.Integer,
                              db.ForeignKey('ref_metro_division.metro_div_id',
                                            deferrable=True,
                                            initially='DEFERRED'),
                              nullable=False,
-                             index=True, primary_key=True)
+                             index=True,
+                             primary_key=True)
 
-    agency = db.relationship('RefAgency', backref='counties')
-    county = db.relationship('RefCounty', backref='agencies')
+    agency = db.relationship('RefAgency', backref='county_associations')
+    county = db.relationship('RefCounty', backref='agency_associations')
     metro_div = db.relationship('RefMetroDivision')
+
+
+class RefAgency(db.Model):
+    __tablename__ = 'ref_agency'
+
+    agency_id = db.Column(db.BigInteger, primary_key=True)
+    ori = db.Column(db.String(9), nullable=False, unique=True)
+    legacy_ori = db.Column(db.String(9), nullable=False)
+    ucr_agency_name = db.Column(db.String(100))
+    ncic_agency_name = db.Column(db.String(100))
+    pub_agency_name = db.Column(db.String(100))
+    special_mailing_group = db.Column(db.String(1))
+    special_mailing_address = db.Column(db.String(1))
+    agency_status = db.Column(db.String(1), nullable=False)
+    judicial_dist_code = db.Column(db.String(4))
+    fid_code = db.Column(db.String(2))
+    added_date = db.Column(db.DateTime(True))
+    change_timestamp = db.Column(db.DateTime(True))
+    change_user = db.Column(db.String(100))
+    legacy_notify_agency = db.Column(db.String(1))
+    dormant_year = db.Column(db.SmallInteger)
+    agency_type_id = db.Column(db.Integer,
+                               db.ForeignKey('ref_agency_type.agency_type_id',
+                                             deferrable=True,
+                                             initially='DEFERRED'),
+                               nullable=False,
+                               index=True)
+    campus_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_university_campus.campus_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          index=True)
+    city_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_city.city_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
+    department_id = db.Column(db.Integer,
+                              db.ForeignKey('ref_department.department_id',
+                                            deferrable=True,
+                                            initially='DEFERRED'),
+                              index=True)
+    field_office_id = db.Column(
+        db.Integer,
+        db.ForeignKey('ref_field_office.field_office_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
+        index=True)
+    population_family_id = db.Column(
+        db.Integer,
+        db.ForeignKey('ref_population_family.population_family_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
+        nullable=False,
+        index=True)
+    state_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_state.state_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         nullable=False,
+                         index=True)
+    submitting_agency_id = db.Column(
+        db.Integer,
+        db.ForeignKey('ref_submitting_agency.agency_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
+        index=True)
+    tribe_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_tribe.tribe_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         index=True)
+
+    agency_type = db.relationship('RefAgencyType', lazy=False)
+    campus = db.relationship('RefUniversityCampu')
+    city = db.relationship('RefCity', lazy=False)
+    department = db.relationship('RefDepartment', lazy=False)
+    field_office = db.relationship('RefFieldOffice', lazy=False)
+    population_family = db.relationship('RefPopulationFamily', lazy=False)
+    state = db.relationship('RefState', lazy=False)
+    submitting_agency = db.relationship('RefSubmittingAgency', lazy=False)
+    tribe = db.relationship('RefTribe')
+    counties = db.relationship('RefCounty',
+                               secondary=RefAgencyCounty.__table__,
+                               collection_class=set)
 
 
 class RefAgencyCoveredBy(db.Model):
     __tablename__ = 'ref_agency_covered_by'
     __table_args__ = (UniqueConstraint('agency_id', 'data_year'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('ref_agency_covered_by_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('ref_agency_covered_by_id_seq'::regclass)"))
     data_year = db.Column(db.SmallInteger, nullable=False)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    covered_by_agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
+    covered_by_agency_id = db.Column(db.Integer,
+                                     db.ForeignKey('ref_agency.agency_id',
+                                                   deferrable=True,
+                                                   initially='DEFERRED'),
+                                     nullable=False,
+                                     index=True)
 
     agency = db.relationship(
         'RefAgency',
         primaryjoin='RefAgencyCoveredBy.agency_id == RefAgency.agency_id')
     covered_by_agency = db.relationship(
         'RefAgency',
-        primaryjoin='RefAgencyCoveredBy.covered_by_agency_id == RefAgency.agency_id'
-    )
+        primaryjoin=
+        'RefAgencyCoveredBy.covered_by_agency_id == RefAgency.agency_id')
 
 
 class RefAgencyDataContent(db.Model):
     __tablename__ = 'ref_agency_data_content'
     __table_args__ = (UniqueConstraint('agency_id', 'data_year'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('ref_agency_data_content_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('ref_agency_data_content_id_seq'::regclass)"))
     data_year = db.Column(db.SmallInteger, nullable=False)
     reporting_type = db.Column(db.String(1))
     nibrs_ct_flag = db.Column(db.String(1))
@@ -1987,12 +1898,12 @@ class RefAgencyDataContent(db.Model):
     nibrs_arson_flag = db.Column(db.String(1))
     summary_rape_def = db.Column(db.String(1))
     nibrs_ht_flag = db.Column(db.String(1))
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -2007,12 +1918,12 @@ class RefAgencyPoc(db.Model):
         server_default=text("nextval('ref_agency_poc_id_seq'::regclass)"))
     agency_id = db.Column(db.BigInteger, nullable=False)
     primary_poc_flag = db.Column(db.String(1))
-    poc_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_poc.poc_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    poc_id = db.Column(db.Integer,
+                       db.ForeignKey('ref_poc.poc_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       nullable=False,
+                       index=True)
 
     poc = db.relationship('RefPoc')
 
@@ -2024,10 +1935,9 @@ class RefAgencyType(db.Model):
     agency_type_name = db.Column(db.String(100))
     default_pop_family_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'ref_population_family.population_family_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('ref_population_family.population_family_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         nullable=False,
         index=True)
 
@@ -2038,11 +1948,10 @@ class RefCampusPopulation(db.Model):
     __tablename__ = 'ref_campus_population'
     __table_args__ = (UniqueConstraint('campus_id', 'data_year'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('ref_campus_population_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('ref_campus_population_id_seq'::regclass)"))
     data_year = db.Column(db.SmallInteger, nullable=False)
     population = db.Column(db.BigInteger)
     source_flag = db.Column(db.String(1), nullable=False)
@@ -2050,14 +1959,12 @@ class RefCampusPopulation(db.Model):
     change_timestamp = db.Column(db.DateTime(True))
     change_user = db.Column(db.String(100))
     reporting_population = db.Column(db.BigInteger)
-    campus_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_university_campus.campus_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    campus_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_university_campus.campus_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     campus = db.relationship('RefUniversityCampu')
 
@@ -2068,12 +1975,12 @@ class RefCity(db.Model):
 
     city_id = db.Column(db.BigInteger, primary_key=True)
     city_name = db.Column(db.String(100))
-    state_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_state.state_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    state_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_state.state_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         nullable=False,
+                         index=True)
 
     state = db.relationship('RefState')
 
@@ -2090,14 +1997,12 @@ class RefCountry(db.Model):
 
     country_id = db.Column(db.SmallInteger, primary_key=True)
     country_desc = db.Column(db.String(50))
-    continent_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_continent.continent_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    continent_id = db.Column(db.Integer,
+                             db.ForeignKey('ref_continent.continent_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
 
     continent = db.relationship('RefContinent')
 
@@ -2111,12 +2016,12 @@ class RefCounty(db.Model):
     county_fips_code = db.Column(db.String(5))
     legacy_county_code = db.Column(db.String(5))
     comments = db.Column(db.String(1000))
-    state_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_state.state_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    state_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_state.state_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         nullable=False,
+                         index=True)
 
     state = db.relationship('RefState')
 
@@ -2125,23 +2030,22 @@ class RefCountyPopulation(db.Model):
     __tablename__ = 'ref_county_population'
     __table_args__ = (UniqueConstraint('county_id', 'data_year'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('ref_county_population_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('ref_county_population_id_seq'::regclass)"))
     data_year = db.Column(db.SmallInteger, nullable=False)
     population = db.Column(db.BigInteger)
     source_flag = db.Column(db.String(1), nullable=False)
     change_timestamp = db.Column(db.DateTime(True))
     change_user = db.Column(db.String(100))
     reporting_population = db.Column(db.BigInteger)
-    county_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_county.county_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    county_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_county.county_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     county = db.relationship('RefCounty')
 
@@ -2162,12 +2066,12 @@ class RefDivision(db.Model):
     division_code = db.Column(db.String(2))
     division_name = db.Column(db.String(100))
     division_desc = db.Column(db.String(100))
-    region_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_region.region_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    region_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_region.region_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     region = db.relationship('RefRegion', lazy=False)
 
@@ -2187,12 +2091,12 @@ class RefGlobalLocation(db.Model):
 
     global_location_id = db.Column(db.BigInteger, primary_key=True)
     global_location_desc = db.Column(db.String(50))
-    country_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_country.country_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    country_id = db.Column(db.Integer,
+                           db.ForeignKey('ref_country.country_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
 
     country = db.relationship('RefCountry')
 
@@ -2201,11 +2105,10 @@ class RefMetroDivPopulation(db.Model):
     __tablename__ = 'ref_metro_div_population'
     __table_args__ = (UniqueConstraint('metro_div_id', 'data_year'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('ref_metro_div_population_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('ref_metro_div_population_id_seq'::regclass)"))
     data_year = db.Column(db.SmallInteger, nullable=False)
     population = db.Column(db.BigInteger)
     source_flag = db.Column(db.String(1), nullable=False)
@@ -2213,14 +2116,12 @@ class RefMetroDivPopulation(db.Model):
     change_timestamp = db.Column(db.DateTime(True))
     change_user = db.Column(db.String(100))
     reporting_population = db.Column(db.BigInteger)
-    metro_div_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_metro_division.metro_div_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    metro_div_id = db.Column(db.Integer,
+                             db.ForeignKey('ref_metro_division.metro_div_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
 
     metro_div = db.relationship('RefMetroDivision')
 
@@ -2233,12 +2134,12 @@ class RefMetroDivision(db.Model):
     msa_flag = db.Column(db.String(1))
     metro_div_omb_code = db.Column(db.String(5))
     legacy_msa_code = db.Column(db.String(5))
-    msa_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_msa.msa_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    msa_id = db.Column(db.Integer,
+                       db.ForeignKey('ref_msa.msa_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       nullable=False,
+                       index=True)
 
     msa = db.relationship('RefMsa')
 
@@ -2261,10 +2162,9 @@ class RefParentPopulationGroup(db.Model):
     publication_name = db.Column(db.String(100))
     population_family_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'ref_population_family.population_family_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('ref_population_family.population_family_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         nullable=False,
         index=True)
 
@@ -2288,11 +2188,11 @@ class RefPoc(db.Model):
     city_name = db.Column(db.String(100))
     poc_fax1 = db.Column(db.String(20))
     poc_fax2 = db.Column(db.String(20))
-    state_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_state.state_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    state_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_state.state_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         index=True)
 
     state = db.relationship('RefState')
 
@@ -2312,18 +2212,18 @@ class RefPocRoleAssign(db.Model):
         db.Integer,
         primary_key=True,
         server_default=text("nextval('ref_poc_role_assign_id_seq'::regclass)"))
-    poc_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_poc.poc_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    poc_role_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_poc_role.poc_role_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    poc_id = db.Column(db.Integer,
+                       db.ForeignKey('ref_poc.poc_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       nullable=False,
+                       index=True)
+    poc_role_id = db.Column(db.Integer,
+                            db.ForeignKey('ref_poc_role.poc_role_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
 
     poc = db.relationship('RefPoc')
     poc_role = db.relationship('RefPocRole')
@@ -2347,10 +2247,9 @@ class RefPopulationGroup(db.Model):
     publication_name = db.Column(db.String(100))
     parent_pop_group_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'ref_parent_population_group.parent_pop_group_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('ref_parent_population_group.parent_pop_group_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         nullable=False,
         index=True)
 
@@ -2376,12 +2275,12 @@ class RefState(db.Model):
     state_postal_abbr = db.Column(db.String(2))
     state_fips_code = db.Column(db.String(2))
     state_pub_freq_months = db.Column(db.SmallInteger)
-    division_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_division.division_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    division_id = db.Column(db.Integer,
+                            db.ForeignKey('ref_division.division_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
 
     division = db.relationship('RefDivision', lazy=False)
 
@@ -2396,11 +2295,11 @@ class RefSubmittingAgency(db.Model):
     agency_email = db.Column(db.String(200))
     agency_website = db.Column(db.String(2000))
     comments = db.Column(db.String(2000))
-    state_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_state.state_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    state_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_state.state_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         index=True)
 
     state = db.relationship('RefState')
 
@@ -2416,11 +2315,10 @@ class RefTribePopulation(db.Model):
     __tablename__ = 'ref_tribe_population'
     __table_args__ = (UniqueConstraint('tribe_id', 'data_year'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text(
-            "nextval('ref_tribe_population_id_seq'::regclass)"))
+    id = db.Column(db.Integer,
+                   primary_key=True,
+                   server_default=text(
+                       "nextval('ref_tribe_population_id_seq'::regclass)"))
     data_year = db.Column(db.SmallInteger, nullable=False)
     population = db.Column(db.BigInteger)
     source_flag = db.Column(db.String(1), nullable=False)
@@ -2428,12 +2326,12 @@ class RefTribePopulation(db.Model):
     change_timestamp = db.Column(db.DateTime(True))
     change_user = db.Column(db.String(100))
     reporting_population = db.Column(db.BigInteger)
-    tribe_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_tribe.tribe_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    tribe_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_tribe.tribe_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         nullable=False,
+                         index=True)
 
     tribe = db.relationship('RefTribe')
 
@@ -2451,14 +2349,12 @@ class RefUniversityCampu(db.Model):
 
     campus_id = db.Column(db.BigInteger, primary_key=True)
     campus_name = db.Column(db.String(100))
-    university_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_university.university_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    university_id = db.Column(db.Integer,
+                              db.ForeignKey('ref_university.university_id',
+                                            deferrable=True,
+                                            initially='DEFERRED'),
+                              nullable=False,
+                              index=True)
 
     university = db.relationship('RefUniversity')
 
@@ -2493,12 +2389,12 @@ class RetaMonth(db.Model):
     update_flag = db.Column(db.String(1))
     did = db.Column(db.BigInteger)
     ff_line_number = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -2522,20 +2418,19 @@ class RetaMonthOffenseSubcat(db.Model):
     cleared_status = db.Column(db.SmallInteger)
     juvenile_cleared_count = db.Column(db.Integer)
     juvenile_cleared_status = db.Column(db.SmallInteger)
-    offense_subcat_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'reta_offense_subcat.offense_subcat_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    reta_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'reta_month.reta_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_subcat_id = db.Column(db.Integer,
+                                  db.ForeignKey(
+                                      'reta_offense_subcat.offense_subcat_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                                  nullable=False,
+                                  index=True)
+    reta_month_id = db.Column(db.Integer,
+                              db.ForeignKey('reta_month.reta_month_id',
+                                            deferrable=True,
+                                            initially='DEFERRED'),
+                              nullable=False,
+                              index=True)
 
     offense_subcat = db.relationship('RetaOffenseSubcat')
     reta_month = db.relationship('RetaMonth')
@@ -2551,17 +2446,15 @@ class RetaOffense(db.Model):
     offense_sort_order = db.Column(db.BigInteger)
     classification_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'offense_classification.classification_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('offense_classification.classification_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
     offense_category_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'reta_offense_category.offense_category_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('reta_offense_category.offense_category_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         nullable=False,
         index=True)
 
@@ -2575,12 +2468,12 @@ class RetaOffenseCategory(db.Model):
     offense_category_id = db.Column(db.SmallInteger, primary_key=True)
     offense_category_name = db.Column(db.String(50))
     offense_category_sort_order = db.Column(db.SmallInteger, nullable=False)
-    crime_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'crime_type.crime_type_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    crime_type_id = db.Column(db.Integer,
+                              db.ForeignKey('crime_type.crime_type_id',
+                                            deferrable=True,
+                                            initially='DEFERRED'),
+                              nullable=False,
+                              index=True)
 
     crime_type = db.relationship('CrimeType')
 
@@ -2595,12 +2488,12 @@ class RetaOffenseSubcat(db.Model):
     offense_subcat_sort_order = db.Column(db.BigInteger)
     part = db.Column(db.String(1))
     crime_index_flag = db.Column(db.String(1))
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'reta_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('reta_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
 
     offense = db.relationship('RetaOffense')
 
@@ -2634,20 +2527,18 @@ class ShrIncident(db.Model):
     orig_format = db.Column(db.String(1))
     did = db.Column(db.BigInteger)
     nibrs_incident_id = db.Column(db.BigInteger)
-    shr_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'shr_month.shr_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    situation_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'shr_situation.situation_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    shr_month_id = db.Column(db.Integer,
+                             db.ForeignKey('shr_month.shr_month_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    situation_id = db.Column(db.Integer,
+                             db.ForeignKey('shr_situation.situation_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
 
     shr_month = db.relationship('ShrMonth')
     situation = db.relationship('ShrSituation')
@@ -2669,12 +2560,12 @@ class ShrMonth(db.Model):
     ff_line_number = db.Column(db.BigInteger)
     ddocname = db.Column(db.String(100))
     did = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -2688,23 +2579,21 @@ class ShrOffender(db.Model):
     sex_code = db.Column(db.String(1))
     nibrs_offense_id = db.Column(db.BigInteger)
     nibrs_offender_id = db.Column(db.BigInteger)
-    age_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_age.age_id', deferrable=True, initially='DEFERRED'),
-        index=True)
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    age_id = db.Column(db.Integer,
+                       db.ForeignKey('nibrs_age.age_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
 
     age = db.relationship('NibrsAge')
     ethnicity = db.relationship('NibrsEthnicity')
@@ -2718,43 +2607,39 @@ class ShrOffense(db.Model):
     nibrs_offense_id = db.Column(db.BigInteger)
     circumstances_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'shr_circumstances.circumstances_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('shr_circumstances.circumstances_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    incident_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'shr_incident.incident_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    offender_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'shr_offender.offender_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    incident_id = db.Column(db.Integer,
+                            db.ForeignKey('shr_incident.incident_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
+    offender_id = db.Column(db.Integer,
+                            db.ForeignKey('shr_offender.offender_id',
+                                          deferrable=True,
+                                          initially='DEFERRED'),
+                            nullable=False,
+                            index=True)
     relationship_id = db.Column(
         db.Integer,
-        db.ForeignKey(
-            'shr_relationship.relationship_id',
-            deferrable=True,
-            initially='DEFERRED'),
+        db.ForeignKey('shr_relationship.relationship_id',
+                      deferrable=True,
+                      initially='DEFERRED'),
         index=True)
-    victim_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'shr_victim.victim_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    weapon_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_weapon_type.weapon_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
+    victim_id = db.Column(db.Integer,
+                          db.ForeignKey('shr_victim.victim_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
+    weapon_id = db.Column(db.Integer,
+                          db.ForeignKey('nibrs_weapon_type.weapon_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          index=True)
 
     circumstances = db.relationship('ShrCircumstance')
     incident = db.relationship('ShrIncident')
@@ -2789,23 +2674,21 @@ class ShrVictim(db.Model):
     sex_code = db.Column(db.String(1))
     nibrs_victim_id = db.Column(db.BigInteger)
     nibrs_offense_id = db.Column(db.BigInteger)
-    age_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_age.age_id', deferrable=True, initially='DEFERRED'),
-        index=True)
-    ethnicity_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'nibrs_ethnicity.ethnicity_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        index=True)
-    race_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_race.race_id', deferrable=True, initially='DEFERRED'),
-        index=True)
+    age_id = db.Column(db.Integer,
+                       db.ForeignKey('nibrs_age.age_id',
+                                     deferrable=True,
+                                     initially='DEFERRED'),
+                       index=True)
+    ethnicity_id = db.Column(db.Integer,
+                             db.ForeignKey('nibrs_ethnicity.ethnicity_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             index=True)
+    race_id = db.Column(db.Integer,
+                        db.ForeignKey('ref_race.race_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                        index=True)
 
     age = db.relationship('NibrsAge')
     ethnicity = db.relationship('NibrsEthnicity')
@@ -2844,12 +2727,12 @@ class SuppMonth(db.Model):
     update_flag = db.Column(db.String(1))
     did = db.Column(db.BigInteger)
     ff_line_number = db.Column(db.BigInteger)
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True)
 
     agency = db.relationship('RefAgency')
 
@@ -2869,12 +2752,12 @@ class SuppOffenseSubcat(db.Model):
     offense_subcat_name = db.Column(db.String(100), nullable=False)
     offense_subcat_code = db.Column(db.String(20), nullable=False)
     offense_subcat_xml_name = db.Column(db.String(100))
-    offense_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'supp_offense.offense_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_id = db.Column(db.Integer,
+                           db.ForeignKey('supp_offense.offense_id',
+                                         deferrable=True,
+                                         initially='DEFERRED'),
+                           nullable=False,
+                           index=True)
 
     offense = db.relationship('SuppOffense')
 
@@ -2892,20 +2775,19 @@ class SuppPropByOffenseSubcat(db.Model):
     actual_status = db.Column(db.SmallInteger)
     stolen_value = db.Column(db.BigInteger)
     stolen_value_status = db.Column(db.SmallInteger)
-    offense_subcat_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'supp_offense_subcat.offense_subcat_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    supp_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'supp_month.supp_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    offense_subcat_id = db.Column(db.Integer,
+                                  db.ForeignKey(
+                                      'supp_offense_subcat.offense_subcat_id',
+                                      deferrable=True,
+                                      initially='DEFERRED'),
+                                  nullable=False,
+                                  index=True)
+    supp_month_id = db.Column(db.Integer,
+                              db.ForeignKey('supp_month.supp_month_id',
+                                            deferrable=True,
+                                            initially='DEFERRED'),
+                              nullable=False,
+                              index=True)
 
     offense_subcat = db.relationship('SuppOffenseSubcat')
     supp_month = db.relationship('SuppMonth')
@@ -2924,20 +2806,18 @@ class SuppPropertyByTypeValue(db.Model):
     stolen_value_status = db.Column(db.SmallInteger)
     recovered_value = db.Column(db.BigInteger)
     recovered_value_status = db.Column(db.SmallInteger)
-    prop_type_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'supp_property_type.prop_type_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    supp_month_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'supp_month.supp_month_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    prop_type_id = db.Column(db.Integer,
+                             db.ForeignKey('supp_property_type.prop_type_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True)
+    supp_month_id = db.Column(db.Integer,
+                              db.ForeignKey('supp_month.supp_month_id',
+                                            deferrable=True,
+                                            initially='DEFERRED'),
+                              nullable=False,
+                              index=True)
 
     prop_type = db.relationship('SuppPropertyType')
     supp_month = db.relationship('SuppMonth')

--- a/crime_data/common/models.py
+++ b/crime_data/common/models.py
@@ -1905,12 +1905,8 @@ class RefAgencyCounty(db.Model):
     __table_args__ = (UniqueConstraint('agency_id', 'county_id',
                                        'metro_div_id', 'data_year'), )
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True,
-        server_default=text("nextval('ref_agency_county_id_seq'::regclass)"))
     core_city_flag = db.Column(db.String(1))
-    data_year = db.Column(db.SmallInteger, nullable=False)
+    data_year = db.Column(db.SmallInteger, nullable=False, primary_key=True)
     population = db.Column(db.BigInteger)
     census = db.Column(db.BigInteger)
     legacy_county_code = db.Column(db.String(20))
@@ -1918,29 +1914,27 @@ class RefAgencyCounty(db.Model):
     source_flag = db.Column(db.String(1))
     change_timestamp = db.Column(db.DateTime(True))
     change_user = db.Column(db.String(100))
-    agency_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_agency.agency_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    county_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_county.county_id', deferrable=True, initially='DEFERRED'),
-        nullable=False,
-        index=True)
-    metro_div_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            'ref_metro_division.metro_div_id',
-            deferrable=True,
-            initially='DEFERRED'),
-        nullable=False,
-        index=True)
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True, primary_key=True)
+    county_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_county.county_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True, primary_key=True)
+    metro_div_id = db.Column(db.Integer,
+                             db.ForeignKey('ref_metro_division.metro_div_id',
+                                           deferrable=True,
+                                           initially='DEFERRED'),
+                             nullable=False,
+                             index=True, primary_key=True)
 
-    agency = db.relationship('RefAgency')
-    county = db.relationship('RefCounty')
+    agency = db.relationship('RefAgency', backref='counties')
+    county = db.relationship('RefCounty', backref='agencies')
     metro_div = db.relationship('RefMetroDivision')
 
 

--- a/tests/functional/test_incidents.py
+++ b/tests/functional/test_incidents.py
@@ -41,6 +41,12 @@ class TestIncidentsEndpoint:
             assert 'agency' in incident
             assert 'ori' in incident['agency']
 
+    def test_incidents_endpoint_includes_counties(self, user, testapp):
+        res = testapp.get('/incidents/')
+        for incident in res.json['results']:
+            agency = incident['agency']
+            assert 'counties' in agency
+
     def test_incidents_endpoint_includes_locations(self, user, testapp):
         res = testapp.get('/incidents/')
         for incident in res.json['results']:
@@ -220,6 +226,12 @@ class TestIncidentsEndpoint:
         results = testapp.get('/incidents/?state=oh')
         for incident in results.json['results']:
             assert incident['agency']['state']['state_abbr'] == 'OH'
+
+    def test_incidents_endpoint_filter_county(self, user, testapp):
+        results = testapp.get('/incidents/?county=warren')
+        for incident in results.json['results']:
+            county_names = [c['county'].lower() for c in incident['agency']['counties']]
+            assert 'warren' in county_names
 
     # End filter tests
 
@@ -401,7 +413,7 @@ class TestIncidentsCountEndpoint:
     def test_incidents_filter_weapon(self, testapp):
         res = testapp.get('/incidents/?offense.weapon_code=40')
         assert res.json['results']
- 
+
     def test_instances_filter_criminal_act(self, testapp):
         res = testapp.get('/incidents/?offense.criminal_act_code=P')
         assert res.json['results']


### PR DESCRIPTION
This inserts a list of all the counties associated with an agency into the results for /incidents/.  It also allows filtering on county name, and filtering/grouping by county in `/incidents/count/`.  One trick there is that you get the results for all agencies that are associated with the county - dividing an agency's reported incidents between its counties is not yet supported.

One thing it doesn't yet do is to report the number of residents of the jurisdiction who live in each of the counties associated with an agency, as would be necessary to proportionally allocate incidents between them.  The trouble with that is that it varies per year, and I don't yet know a way to limit the output to only the year of interest.  