### PR TITLE
Added ability to view flattened one-to-many attributes in CSV.

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -233,7 +233,7 @@ class CdeResource(Resource):
             # Fill in any missing keys.
             empty = dict.fromkeys(set().union(*to_csv), 0)
             to_csv = [dict(empty, **d) for d in to_csv]
-            # exit(1)
+
             # Generate CSV.
             # TODO: Sort by columns.
             count = 0

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -29,6 +29,7 @@ class SchemaFormater(object):
 # Schemas for request parsing
 class ArgumentsSchema(Schema):
     output = marsh_fields.String(missing='json')
+    aggregate_many = marsh_fields.String(missing='false')
     page = marsh_fields.Integer(missing=1)
     per_page = marsh_fields.Integer(missing=10)
     fields = marsh_fields.String()

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -27,10 +27,14 @@ class IncidentsList(CdeResource):
         self.verify_api_key(args)
         filters = self.filters(args)
         qry = self.tables.filtered(filters)
+        aggregate_many = False
+
+        if args['aggregate_many'] == 'true':
+            aggregate_many = True
 
         if args['output'] == 'csv':
             output = make_response(self.output_serialize(
-                self.with_metadata(qry, args), self.schema))
+                self.with_metadata(qry, args), self.schema, 'csv', aggregate_many))
             output.headers[
                 "Content-Disposition"] = "attachment; filename=incidents.csv"
             output.headers["Content-type"] = "text/csv"


### PR DESCRIPTION
This adds the ability to toggle between seeing one-to-many fields listed out in CSV like:

offenses_0..., offenses_1...., offenses_2,...

and,

offenses (count), ...


with the url attribute: aggregate_many=false/true