### PR TITLE
Wrong dir for static in codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,5 +22,6 @@ ratings:
     - "**.rb"
 exclude_paths:
   - tests/
-  - static/
+  - crime_data/static/
   - migrations/
+  - dba/


### PR DESCRIPTION
Want to avoid anaylzing files in the /static/ directory