### PR TITLE
Have the duplication engine skip models/schemas

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,9 +1,14 @@
 engines:
   duplication:
     enabled: true
+    exclude_paths:
+      - crime_data/common/models.py
+      - crime_data/common/cdemodels.py
+      - crime_data/common/marshmallow_schemas.py
     config:
       languages:
-        - python
+        python:
+          python_version: 3
   fixme:
     enabled: true
   pep8:


### PR DESCRIPTION
These were triggering a lot of false positives for the duplication engine since we have a lot of tables with similar structures, so I have disabled the duplication checks for those files