### PR TITLE
Basic Swagger generation from the code

### DIFF
--- a/SWAGGER.md
+++ b/SWAGGER.md
@@ -1,0 +1,172 @@
+# Swagger
+
+To make it easier to see what the APIs can do, this project includes
+endpoints the return [Swagger](http://swagger.io/) documentation for
+the API. These documents are not yet complete or consistent and can
+not yet be used to automatically generate API clients or to validate
+API responses. But they do let you test out the API and see roughly
+what the valid behavior is.
+
+## Initial Setup
+
+Currently, both endpoints must be secured behind HTTP Authentication
+to deter unauthorized access. To use these endpoints locally, you can
+try the following commands in your shell.
+
+``` shell
+export HTTP_USERNAME=username
+export HTTP_PASSWORD=password
+```
+
+Similarly, to use these endpoints on CloudFoundry, you will have to do the following
+
+``` shell
+cf set-env crime-data-api HTTP_USERNAME username
+cf set-env crime-date-api HTTP_PASSWORD password
+cf restage crime-data-api
+```
+
+The HTTP authentication is mandatory while the application is being
+developed. You can't bypass it by setting the username or password to
+blanks. Also, maybe try something different for both of them and limit
+distribution only to authorized personnel.
+
+## Swagger Endpoints
+
+The [/swagger/](https://crime-data-api.fr.cloud.gov/swagger/) returns
+a dynamically generated `swagger.json` file with a listing of all the
+endpoints and their parameters.
+
+The [/swagger-ui/](https://crime-data-api.fr.cloud.gov/swagger-ui/)
+path returns the Swagger-UI, an interactive view of the endpoints that
+lets you see input parameters, output formats and even lets you run
+queries against the API.
+
+## Adding a New Method
+
+We are using
+the [flask-apispec](https://github.com/jmcarp/flask-apispec) library
+for generating the Swagger documentation and UI. This is a convenient
+mechanism that lets us document our endpoints with only decorators:
+
+``` python
+import flask_apispec as swagger
+
+class IncidentsList(CdeResource):
+
+    schema = marshmallow_schemas.NibrsIncidentSchema(many=True)
+    tables = cdemodels.IncidentTableFamily()
+    # Enable fast counting.
+    fast_count = True
+
+    @use_args(marshmallow_schemas.ArgumentsSchema)
+    @swagger.doc(tags=['incidents'],
+                 description=('Return all matching incidents. Queries can drill down '
+                              'on specific values for fields within the incidents record.')
+    )
+    @swagger.use_kwargs(marshmallow_schemas.ArgumentsSchema, apply=False, locations=['query'])
+    @swagger.marshal_with(marshmallow_schemas.IncidentsListResponseSchema, apply=False)
+    @tuning_page
+    def get(self, args):
+        return self._get(args)
+
+```
+
+The flask-apispec library is meant to be used for RESTful
+applications, and by default its decorators define the allowed schema
+for parsing or returning arguments in addition to documenting those
+schema within Swagger. The Crime Data API is not RESTful and many API
+methods allow the user to specify additional fields as part of the
+request (ie, `/incidents/?victim.age_num=24`) or might return
+additional fields (ie, when you use the `by` parameter to group
+counts, each count result will include the fields being grouped
+by). We use the `apply=False` argument with flask-apispec decorators
+to tell it that we only want to describe the endpoint with APISpec;
+otherwise it will use the supplied Marshmallow schemas to
+parse/serialize responses and discard any additional fields.
+
+If you are adding a new endpoint, there are three decorators that can
+be applied to functions.
+
+
+``` python
+@swagger.doc(tags=['incidents'],
+             description=('Return all matching incidents. Queries can drill down '
+                          'on specific values for fields within the incidents record.')
+)
+@swagger.use_kwargs(marshmallow_schemas.ArgumentsSchema, apply=False, locations=['query'])
+@swagger.marshal_with(marshmallow_schemas.IncidentsListResponseSchema, apply=False)
+```
+
+The `@doc` decorator allows you to specify a description for the API
+in Markdown. Tags are used to group together related API endpoints (if
+you tag an API with multiple tags, it will show up in several places
+in the Swagger UI).
+
+The `@use_kwargs` decorator is used to specify what arguments the API
+method takes. It takes either a dict of fields or a Marshmallow schema
+like those we are using already. This could normally be used for
+webargs processing, but we already are using the `@use_args` decorator
+from webargs, and flask-apispec currently only has support for
+translating input parameters to kwargs (which makes sense in a RESTful
+API, but not for one that supports arbitrary queries). So we tell
+flask-apispec to only use this information for documentation with the
+`apply=False` argument and we use the `locations=['query']` argument
+to specify that parameters are only specified as query parameters on
+the URL.
+
+The `@marshal_with` decorator tells `flask-apispec` what the return
+type of the API method will be. It takes a Marshmallow schema as its
+type. As before, we send it the `apply=False` argument to limit its
+functionality specifically to documenting the returned type in
+Swagger. Since many of our response return their data in a paginated
+structure like
+
+``` json
+{
+  "pagination": {...}
+  "results": [{...}, {...} ...]
+}
+```
+
+it might be necessary to define a Marshmallow schema for the response
+that inherits from a basic response schema that captures the paginated
+structure. For instance, the `IncidentsListResponseSchema` specified above looks like
+
+``` python
+class IncidentsListResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(NibrsIncidentSchema, many=True)
+```
+
+Of course, since we are only using flask-apispec for generating the
+documentation, it won't cause the program to crash if you specify an
+incorrect or incomplete schema. But it's better to be more specific
+about what it returns.
+
+## Missing Pieces
+
+There are some rough edges, but this has been the fastest way to get a
+Swagger UI that tracks the actual functionality of our application as
+we develop it. This is still not a complete Swagger specification
+though, and we will need to fix the following issues eventually should
+we decide to make the Swagger JSON public for outside developers to use:
+
+* Figure out the best ways to represent the allowed but optional query
+  parameters for most endpoints within the Swagger API. Since there
+  are hundreds of these, they may overwhelm the interface. In
+  addition, figuring out these parameters involves a DB query with an
+  app context that may not be easily accommodated within a decorator.
+* The output schema is currently generated by traversing Marshmallow
+  schemas. Figure out if there is a better way to embed documentation
+  in the Marshmallow Field type that can be passed along to
+  Swagger. In addition, figure out if we can declare that the
+  Marshmallow schema might include additional fields.
+* It seems a bit redundant to have both `flask-restful` and
+  `flask-apispec` on the project. If we could create a `@use_args`
+  decorator for `flask-apispec` that might be enough to remove one of
+  these libraries.
+
+None of this remaining work is particularly urgent, and it might be
+something that we just decide to avoid altogether, since both
+`flask-apispec` and `Swagger` itself are meant to be used for RESTful
+APIs and the Crime Data API most certainly is not.

--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -2,6 +2,7 @@
 """The app module, containing the app factory function."""
 import csv
 import io
+from os import getenv
 
 import flask_restful as restful
 from flask import Flask, render_template
@@ -97,6 +98,7 @@ def register_commands(app):
 
 
 def add_resources(app):
+    """Register API routes and Swagger endpoints"""
     api = restful.Api(app)
 
     @api.representation('text/csv')
@@ -135,6 +137,26 @@ def add_resources(app):
                      '/arrests/age_sex/')
     api.add_resource(crime_data.resources.arson.ArsonCountResource, '/arson/')
 
+    # Wrap swagger in HTTP Auth. Can be removed after ATO
+    from flask_httpauth import HTTPBasicAuth
+    auth = HTTPBasicAuth()
+
+    @auth.get_password
+    def get_pw(username):
+        target_username = getenv('HTTP_USERNAME')
+        target_password = getenv('HTTP_PASSWORD')
+
+        if target_username is None or target_password is None:
+            return None
+
+        if username == target_username:
+            return target_password
+
+        return None
+
+    FlaskApiSpec.swagger_json = auth.login_required(FlaskApiSpec.swagger_json)
+    FlaskApiSpec.swagger_ui = auth.login_required(FlaskApiSpec.swagger_ui)
+    # end of HTTP Auth protection for Swagger endpoints
 
     docs = FlaskApiSpec(app)
     docs.register(crime_data.resources.agencies.AgenciesDetail)

--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -20,6 +20,7 @@ from crime_data.common.marshmallow_schemas import ma
 from crime_data.common.models import db
 from crime_data.extensions import (bcrypt, cache, csrf_protect, debug_toolbar,
                                    login_manager, migrate)
+from flask_apispec.extension import FlaskApiSpec
 from crime_data.settings import ProdConfig
 
 if __name__ == '__main__':
@@ -133,3 +134,11 @@ def add_resources(app):
     api.add_resource(crime_data.resources.arrests.ArrestsCountByAgeSex,
                      '/arrests/age_sex/')
     api.add_resource(crime_data.resources.arson.ArsonCountResource, '/arson/')
+
+
+    docs = FlaskApiSpec(app)
+    docs.register(crime_data.resources.agencies.AgenciesDetail)
+    docs.register(crime_data.resources.agencies.AgenciesList)
+    docs.register(crime_data.resources.incidents.IncidentsCount)
+    docs.register(crime_data.resources.incidents.IncidentsDetail)
+    docs.register(crime_data.resources.incidents.IncidentsList)

--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -164,3 +164,4 @@ def add_resources(app):
     docs.register(crime_data.resources.incidents.IncidentsCount)
     docs.register(crime_data.resources.incidents.IncidentsDetail)
     docs.register(crime_data.resources.incidents.IncidentsList)
+    docs.register(crime_data.resources.offenses.OffensesList)

--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -165,3 +165,6 @@ def add_resources(app):
     docs.register(crime_data.resources.incidents.IncidentsDetail)
     docs.register(crime_data.resources.incidents.IncidentsList)
     docs.register(crime_data.resources.offenses.OffensesList)
+    docs.register(crime_data.resources.arrests.ArrestsCountByRace)
+    docs.register(crime_data.resources.arrests.ArrestsCountByEthnicity)
+    docs.register(crime_data.resources.arrests.ArrestsCountByAgeSex)

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -7,7 +7,8 @@ from functools import wraps
 
 import sqltap
 from flask import make_response, request
-from flask_restful import Resource, abort, current_app
+from flask_restful import abort, current_app
+from flask_apispec.views import MethodResource
 # import celery
 from flask_sqlalchemy import SignallingSession, SQLAlchemy
 from sqlalchemy import func, or_
@@ -17,6 +18,23 @@ def tuning_page(f):
     @wraps(f)
     def decorated_get(*args, **kwargs):
         if 'tuning' in args[1] and args[1]['tuning']:
+            if not current_app.config['DEBUG']:
+                abort(403, message="`DEBUG` must be on for tuning page")
+            profiler = sqltap.start()
+            result = f(*args, **kwargs)
+            profiler.stop()
+            stats = profiler.collect()
+            return make_response(sqltap.report(stats, 'tuning.html'))
+        result = f(*args, **kwargs)
+        return result
+
+    return decorated_get
+
+
+def tuning_page_kwargs(f):
+    @wraps(f)
+    def decorated_get(*args, **kwargs):
+        if 'tuning' in kwargs and kwargs['tuning']:
             if not current_app.config['DEBUG']:
                 abort(403, message="`DEBUG` must be on for tuning page")
             profiler = sqltap.start()
@@ -159,7 +177,7 @@ class RoutingSQLAlchemy(SQLAlchemy):
         return RoutingSession(self, **options)
 
 
-class CdeResource(Resource):
+class CdeResource(MethodResource):
     __abstract__ = True
     schema = None
     # Enable fast counting.

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -345,6 +345,12 @@ class TableFamily:
             self._build_map()
         return self._map
 
+    @property
+    def input_args(self):
+        """Returns a hash of names: type for Swagger"""
+        out = {key: pair[1].type for key, pair in self.map.items()}
+        return out
+
     def base_query(self):
         """Gets root Query, based on class's base_table"""
         return db.session.query(self.base_table.table)

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -14,11 +14,13 @@ AGE_CODES = {'BB': 0, 'NB': 0, 'NN': 0, '99': 99, }
 
 
 class SchemaFormater(object):
+    """Useful methods for schema transformations"""
+
+
     @classmethod
     def format_age(cls, data):
-        """Turns the age_num field into
-        something a little more useful.
-        """
+        """Turns the age_num field into something a little more useful."""
+
         if 'age_num' in data and data['age']:
             if data['age']['age_code'] in AGE_CODES:
                 data['age_num'] = AGE_CODES[data['age']['age_code']]
@@ -27,6 +29,8 @@ class SchemaFormater(object):
 
 # Schemas for request parsing
 class ArgumentsSchema(Schema):
+    """Input arguments for many API methods"""
+
     output = marsh_fields.String(missing='json')
     aggregate_many = marsh_fields.String(missing='false')
     page = marsh_fields.Integer(missing=1)
@@ -40,10 +44,17 @@ class ArgumentsSchema(Schema):
 
 
 class GroupableArgsSchema(ArgumentsSchema):
+    """
+    Groupable queries can be grouped by one or more fields found in the
+    tables separated by commas
+    """
+
     by = marsh_fields.String(missing='year')
 
 
 class AgenciesIncidentArgsSchema(ArgumentsSchema):
+    """Extra parameters apply to queries against the incidents table."""
+
     incident_hour = marsh_fields.Integer()
     crime_against = marsh_fields.String()
     offense_code = marsh_fields.String()
@@ -57,6 +68,8 @@ class AgenciesIncidentArgsSchema(ArgumentsSchema):
 
 
 class AgenciesRetaArgsSchema(ArgumentsSchema):
+    """RET A Agencies can be queried with additional arguments."""
+
     state = marsh_fields.String()
     ori = marsh_fields.String()
     victim_ethnicity = marsh_fields.String()
@@ -64,19 +77,16 @@ class AgenciesRetaArgsSchema(ArgumentsSchema):
     by = marsh_fields.String(missing='ori')
 
 
-# Schema for pagination
-
 class PaginationSchema(Schema):
+    """Many API methods include a Pagination record in their responses."""
+
     count = marsh_fields.Integer(dumpOnly=True)
     page = marsh_fields.Integer(dumpOnly=True)
     pages = marsh_fields.Integer(dumpOnly=True)
     per_page = marsh_fields.Integer(dumpOnly=True)
 
 
-
 # Schemas for data serialization
-
-
 class NibrsRelationshipSchema(ma.ModelSchema):
     class Meta:
         model = models.NibrsRelationship
@@ -170,7 +180,7 @@ class RefCitySchema(ma.ModelSchema):
         exclude = ('city_id', 'state', )
         ordered = True
 
-#    state = ma.Nested(RefStateSchema)
+    state = ma.Nested(RefStateSchema)
 
 
 class RefContinentSchema(ma.ModelSchema):
@@ -640,37 +650,83 @@ class SuppPropertyTypeSchema(ma.ModelSchema):
 
 ### Count schemas
 class IncidentCountSchema(Schema):
+    """
+    The basic response fields for an incident count query. There might
+    be additional fields in each record if more detailed groupings are
+    specified using the `by` parameter.
+    """
+
     class Meta:
         ordered = True
 
-    actual_count = marsh_fields.Integer()
-    reported_count = marsh_fields.Integer()
-    unfounded_count = marsh_fields.Integer()
-    cleared_count = marsh_fields.Integer()
-    juvenile_cleared_count = marsh_fields.Integer()
-    year = marsh_fields.Integer()
+    actual_count = marsh_fields.Integer(dump_only=True)
+    reported_count = marsh_fields.Integer(dump_only=True)
+    unfounded_count = marsh_fields.Integer(dump_only=True)
+    cleared_count = marsh_fields.Integer(dump_only=True)
+    juvenile_cleared_count = marsh_fields.Integer(dump_only=True)
+    year = marsh_fields.Integer(dump_only=True)
 
-### response schemas
+
+class ArsonCountSchema(Schema):
+    """
+    The basic response for an arson count response. These records might
+    contain additional information depending on what fields are specified
+    for the `by` parameter
+    """
+
+    class Meta:
+        ordered = True
+
+    actual_count = marsh_fields.Integer(dump_only=True)
+    cleared_count = marsh_fields.Integer(dump_only=True)
+    est_damage_value = marsh_fields.Integer(dump_only=True)
+    juvenile_cleared_count = marsh_fields.Integer(dump_only=True)
+    reported_count = marsh_fields.Integer(dump_only=True)
+    unfounded_count = marsh_fields.Integer(dump_only=True)
+    uninhabited_count = marsh_fields.Integer(dump_only=True)
+    year = marsh_fields.Integer(dump_only=True)
+
+
+# response schemas
 class PaginatedResponseSchema(Schema):
+    """
+    Many endpoints return paginated responses with both pagination and
+    results subrecords
+    """
+
     class Meta:
         ordered = True
 
     pagination = ma.Nested(PaginationSchema)
 
+
 class AgenciesListResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(RefAgencySchema, many=True)
+
 
 class AgenciesDetailResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(RefAgencySchema)
 
+
 class IncidentsCountResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(IncidentCountSchema, many=True)
+
 
 class IncidentsDetailResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(NibrsIncidentSchema)
 
+
 class IncidentsListResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(NibrsIncidentSchema, many=True)
 
+
 class OffensesListResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(CrimeTypeSchema, many=True)
+
+
+class ArsonCountResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(ArsonCountSchema, many=True)
+
+
+class CodeIndexResponseSchema(Schema):
+    key = marsh_fields.String()

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -667,3 +667,6 @@ class IncidentsDetailResponseSchema(PaginatedResponseSchema):
 
 class IncidentsListResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(NibrsIncidentSchema, many=True)
+
+class OffensesListResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(CrimeTypeSchema, many=True)

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -5,7 +5,6 @@ import os
 from flask_marshmallow import Marshmallow
 from marshmallow import fields as marsh_fields
 from marshmallow import Schema, post_dump
-
 from . import cdemodels, models
 
 ma = Marshmallow()
@@ -63,6 +62,17 @@ class AgenciesRetaArgsSchema(ArgumentsSchema):
     victim_ethnicity = marsh_fields.String()
     offender_ethnicity = marsh_fields.String()
     by = marsh_fields.String(missing='ori')
+
+
+# Schema for pagination
+
+class PaginationSchema(Schema):
+    count = marsh_fields.Integer(dumpOnly=True)
+    page = marsh_fields.Integer(dumpOnly=True)
+    pages = marsh_fields.Integer(dumpOnly=True)
+    per_page = marsh_fields.Integer(dumpOnly=True)
+
+
 
 # Schemas for data serialization
 
@@ -508,6 +518,7 @@ class NibrsIncidentSchema(ma.ModelSchema):
     offenders = ma.Nested(NibrsOffenderSchema, many=True)
 
 
+
 class NibrsAssignmentTypeSchema(ma.ModelSchema):
     class Meta:
         model = models.NibrsAssignmentType
@@ -625,3 +636,34 @@ class SuppPropertyTypeSchema(ma.ModelSchema):
         model = models.SuppPropertyType
         exclude = ('property_type_id', )
         ordered = True
+
+
+### Count schemas
+class IncidentCountSchema(Schema):
+    class Meta:
+        ordered = True
+
+    actual_count = marsh_fields.Integer()
+    reported_count = marsh_fields.Integer()
+    unfounded_count = marsh_fields.Integer()
+    cleared_count = marsh_fields.Integer()
+    juvenile_cleared_count = marsh_fields.Integer()
+
+### response schemas
+class PaginatedResponseSchema(Schema):
+    class Meta:
+        ordered = True
+
+    pagination = ma.Nested(PaginationSchema)
+
+class AgenciesListResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(RefAgencySchema, many=True)
+
+class AgenciesDetailResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(RefAgencySchema)
+
+class IncidentsDetailResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(NibrsIncidentSchema)
+
+class IncidentsListResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(NibrsIncidentSchema, many=True)

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -648,6 +648,7 @@ class IncidentCountSchema(Schema):
     unfounded_count = marsh_fields.Integer()
     cleared_count = marsh_fields.Integer()
     juvenile_cleared_count = marsh_fields.Integer()
+    year = marsh_fields.Integer()
 
 ### response schemas
 class PaginatedResponseSchema(Schema):
@@ -661,6 +662,9 @@ class AgenciesListResponseSchema(PaginatedResponseSchema):
 
 class AgenciesDetailResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(RefAgencySchema)
+
+class IncidentsCountResponseSchema(PaginatedResponseSchema):
+    results = ma.Nested(IncidentCountSchema, many=True)
 
 class IncidentsDetailResponseSchema(PaginatedResponseSchema):
     results = ma.Nested(NibrsIncidentSchema)

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -2,6 +2,7 @@ import re
 
 from flask_restful import fields, marshal_with, reqparse
 from webargs.flaskparser import use_args
+from flask_apispec import marshal_with
 
 from crime_data.common import cdemodels as models
 from crime_data.common import marshmallow_schemas
@@ -18,6 +19,7 @@ class AgenciesResource(CdeResource):
 
 class AgenciesList(AgenciesResource):
     @use_args(marshmallow_schemas.RefAgencySchema)
+    @marshal_with(marshmallow_schemas.AgenciesListResponseSchema)
     def get(self, args):
         self.verify_api_key(args)
         result = models.CdeRefAgency.get()
@@ -26,6 +28,7 @@ class AgenciesList(AgenciesResource):
 
 class AgenciesDetail(AgenciesResource):
     @use_args(marshmallow_schemas.ArgumentsSchema)
+    @marshal_with(marshmallow_schemas.AgenciesDetailResponseSchema)
     def get(self, args, nbr):
         self.verify_api_key(args)
         agency = models.CdeRefAgency.get(nbr)

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -2,7 +2,7 @@ import re
 
 from flask_restful import fields, marshal_with, reqparse
 from webargs.flaskparser import use_args
-from flask_apispec import marshal_with, doc
+import flask_apispec as swagger
 
 from crime_data.common import cdemodels as models
 from crime_data.common import marshmallow_schemas
@@ -13,15 +13,15 @@ from crime_data.common.marshmallow_schemas import (
 
 
 class AgenciesResource(CdeResource):
-
     schema = marshmallow_schemas.RefAgencySchema(many=True)
 
 
 class AgenciesList(AgenciesResource):
     @use_args(marshmallow_schemas.RefAgencySchema)
-    @marshal_with(marshmallow_schemas.AgenciesListResponseSchema)
-    @doc(tags=["agencies"],
-         description="Returns a paginated list of all agencies")
+    @swagger.use_kwargs(marshmallow_schemas.RefAgencySchema, apply=False, locations=['query'])
+    @swagger.marshal_with(marshmallow_schemas.AgenciesListResponseSchema, apply=False)
+    @swagger.doc(tags=['agencies'],
+                 description='Returns a paginated list of all agencies')
     def get(self, args):
         self.verify_api_key(args)
         result = models.CdeRefAgency.get()
@@ -30,9 +30,10 @@ class AgenciesList(AgenciesResource):
 
 class AgenciesDetail(AgenciesResource):
     @use_args(marshmallow_schemas.ArgumentsSchema)
-    @doc(tags=["agencies"],
-         description="Returns information on a single agency")
-    @marshal_with(marshmallow_schemas.AgenciesDetailResponseSchema)
+    @swagger.use_kwargs(marshmallow_schemas.ArgumentsSchema, apply=False, locations=['query'])
+    @swagger.doc(tags=['agencies'],
+                 description='Returns information on a single agency')
+    @swagger.marshal_with(marshmallow_schemas.AgenciesDetailResponseSchema, apply=False)
     def get(self, args, nbr):
         self.verify_api_key(args)
         agency = models.CdeRefAgency.get(nbr)

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -2,7 +2,7 @@ import re
 
 from flask_restful import fields, marshal_with, reqparse
 from webargs.flaskparser import use_args
-from flask_apispec import marshal_with
+from flask_apispec import marshal_with, doc
 
 from crime_data.common import cdemodels as models
 from crime_data.common import marshmallow_schemas
@@ -20,6 +20,8 @@ class AgenciesResource(CdeResource):
 class AgenciesList(AgenciesResource):
     @use_args(marshmallow_schemas.RefAgencySchema)
     @marshal_with(marshmallow_schemas.AgenciesListResponseSchema)
+    @doc(tags=["agencies"],
+         description="Returns a paginated list of all agencies")
     def get(self, args):
         self.verify_api_key(args)
         result = models.CdeRefAgency.get()
@@ -28,6 +30,8 @@ class AgenciesList(AgenciesResource):
 
 class AgenciesDetail(AgenciesResource):
     @use_args(marshmallow_schemas.ArgumentsSchema)
+    @doc(tags=["agencies"],
+         description="Returns information on a single agency")
     @marshal_with(marshmallow_schemas.AgenciesDetailResponseSchema)
     def get(self, args, nbr):
         self.verify_api_key(args)

--- a/crime_data/resources/arrests.py
+++ b/crime_data/resources/arrests.py
@@ -1,5 +1,5 @@
 from webargs.flaskparser import use_args
-from flask_apispec import doc
+import flask_apispec as swagger
 
 from crime_data.common import cdemodels, marshmallow_schemas
 from crime_data.common.base import CdeResource, tuning_page
@@ -10,8 +10,9 @@ class ArrestsCountResource(CdeResource):
     is_groupable = True
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
-    @doc(tags=['arrests'],
-         description="Returns counts of arrests. These can be grouped further with the by column.")
+    @swagger.use_kwargs(marshmallow_schemas.GroupableArgsSchema, apply=False, locations=['query'])
+    @swagger.doc(tags=['arrests'],
+                 description='Returns counts of arrests. These can be grouped further with the by column.')
     @tuning_page
     def get(self, args):
         return self._get(args)
@@ -22,8 +23,9 @@ class ArrestsCountByRace(ArrestsCountResource):
     tables = cdemodels.ArrestsByRaceTableFamily()
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
-    @doc(tags=['arrests'],
-         description="Returns counts of arrests. These can be grouped further with the by column.")
+    @swagger.use_kwargs(marshmallow_schemas.GroupableArgsSchema, apply=False, locations=['query'])
+    @swagger.doc(tags=['arrests'],
+                 description='Returns counts of arrests. These can be grouped further with the by column.')
     @tuning_page
     def get(self, args):
         return self._get(args)
@@ -34,8 +36,9 @@ class ArrestsCountByEthnicity(ArrestsCountResource):
     tables = cdemodels.ArrestsByEthnicityTableFamily()
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
-    @doc(tags=['arrests'],
-         description="Returns counts of arrests. These can be grouped further with the by column.")
+    @swagger.use_kwargs(marshmallow_schemas.GroupableArgsSchema, apply=False, locations=['query'])
+    @swagger.doc(tags=['arrests'],
+                 description='Returns counts of arrests. These can be grouped further with the by column.')
     @tuning_page
     def get(self, args):
         return self._get(args)
@@ -46,8 +49,9 @@ class ArrestsCountByAgeSex(ArrestsCountResource):
     tables = cdemodels.ArrestsByAgeSexTableFamily()
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
-    @doc(tags=['arrests'],
-         description="Returns counts of arrests. These can be grouped further with the by column.")
+    @swagger.use_kwargs(marshmallow_schemas.GroupableArgsSchema, apply=False, locations=['query'])
+    @swagger.doc(tags=['arrests'],
+                 description='Returns counts of arrests. These can be grouped further with the by column.')
     @tuning_page
     def get(self, args):
         return self._get(args)

--- a/crime_data/resources/arrests.py
+++ b/crime_data/resources/arrests.py
@@ -1,4 +1,5 @@
 from webargs.flaskparser import use_args
+from flask_apispec import marshal_with
 
 from crime_data.common import cdemodels, marshmallow_schemas
 from crime_data.common.base import CdeResource, tuning_page

--- a/crime_data/resources/arrests.py
+++ b/crime_data/resources/arrests.py
@@ -1,5 +1,5 @@
 from webargs.flaskparser import use_args
-from flask_apispec import marshal_with
+from flask_apispec import doc
 
 from crime_data.common import cdemodels, marshmallow_schemas
 from crime_data.common.base import CdeResource, tuning_page
@@ -10,6 +10,8 @@ class ArrestsCountResource(CdeResource):
     is_groupable = True
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
+    @doc(tags=['arrests'],
+         description="Returns counts of arrests. These can be grouped further with the by column.")
     @tuning_page
     def get(self, args):
         return self._get(args)
@@ -19,15 +21,36 @@ class ArrestsCountByRace(ArrestsCountResource):
 
     tables = cdemodels.ArrestsByRaceTableFamily()
 
+    @use_args(marshmallow_schemas.GroupableArgsSchema)
+    @doc(tags=['arrests'],
+         description="Returns counts of arrests. These can be grouped further with the by column.")
+    @tuning_page
+    def get(self, args):
+        return self._get(args)
+
 
 class ArrestsCountByEthnicity(ArrestsCountResource):
 
     tables = cdemodels.ArrestsByEthnicityTableFamily()
 
+    @use_args(marshmallow_schemas.GroupableArgsSchema)
+    @doc(tags=['arrests'],
+         description="Returns counts of arrests. These can be grouped further with the by column.")
+    @tuning_page
+    def get(self, args):
+        return self._get(args)
+
 
 class ArrestsCountByAgeSex(ArrestsCountResource):
 
     tables = cdemodels.ArrestsByAgeSexTableFamily()
+
+    @use_args(marshmallow_schemas.GroupableArgsSchema)
+    @doc(tags=['arrests'],
+         description="Returns counts of arrests. These can be grouped further with the by column.")
+    @tuning_page
+    def get(self, args):
+        return self._get(args)
 
 
 """

--- a/crime_data/resources/arson.py
+++ b/crime_data/resources/arson.py
@@ -1,4 +1,5 @@
 from webargs.flaskparser import use_args
+import flask_apispec as swagger
 
 from crime_data.common import cdemodels, marshmallow_schemas
 from crime_data.common.base import CdeResource, tuning_page
@@ -10,6 +11,8 @@ class ArsonCountResource(CdeResource):
     is_groupable = True
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
+    @swagger.use_kwargs(marshmallow_schemas.GroupableArgsSchema, apply=False, positions=['query'])
+    @swagger.marshal_with(marshmallow_schemas.ArsonCountResponseSchema, apply=False)
     @tuning_page
     def get(self, args):
         return self._get(args)

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -48,7 +48,6 @@ class IncidentsCount(CdeResource):
     is_groupable = True
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
-    @marshal_with(marshmallow_schemas.IncidentCountSchema)
     @doc(tags=['incidents'],
          description="Returns counts by year for incidents. Incidents can be grouped for counting with the `by` parameter")
     @tuning_page

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -1,8 +1,8 @@
 from webargs.flaskparser import use_args
-from flask_apispec import marshal_with, use_kwargs
+from flask_apispec import marshal_with, doc
 
 from crime_data.common import cdemodels, marshmallow_schemas, models
-from crime_data.common.base import CdeResource, tuning_page, tuning_page_kwargs
+from crime_data.common.base import CdeResource, tuning_page
 
 
 def _is_string(col):
@@ -18,6 +18,8 @@ class IncidentsList(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
+    @doc(tags=['incidents'],
+         description="Return all matching incidents. Queries can drill down on specific values for fields within the incidents record.")
     @marshal_with(marshmallow_schemas.IncidentsListResponseSchema)
     @tuning_page
     def get(self, args):
@@ -32,6 +34,8 @@ class IncidentsDetail(CdeResource):
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
     @marshal_with(marshmallow_schemas.IncidentsDetailResponseSchema)
+    @doc(tags=['incidents'],
+         description="Return the specific record for a single incident")
     @tuning_page
     def get(self, args, nbr):
         self.verify_api_key(args)
@@ -45,6 +49,8 @@ class IncidentsCount(CdeResource):
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
     @marshal_with(marshmallow_schemas.IncidentCountSchema)
+    @doc(tags=['incidents'],
+         description="Returns counts by year for incidents. Incidents can be grouped for counting with the `by` parameter")
     @tuning_page
     def get(self, args):
         return self._get(args)

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -1,7 +1,8 @@
 from webargs.flaskparser import use_args
+from flask_apispec import marshal_with, use_kwargs
 
 from crime_data.common import cdemodels, marshmallow_schemas, models
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, tuning_page_kwargs
 
 
 def _is_string(col):
@@ -17,6 +18,7 @@ class IncidentsList(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
+    @marshal_with(marshmallow_schemas.IncidentsListResponseSchema)
     @tuning_page
     def get(self, args):
         return self._get(args)
@@ -29,6 +31,7 @@ class IncidentsDetail(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
+    @marshal_with(marshmallow_schemas.IncidentsDetailResponseSchema)
     @tuning_page
     def get(self, args, nbr):
         self.verify_api_key(args)
@@ -37,11 +40,11 @@ class IncidentsDetail(CdeResource):
 
 
 class IncidentsCount(CdeResource):
-
     tables = cdemodels.IncidentCountTableFamily()
     is_groupable = True
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
+    @marshal_with(marshmallow_schemas.IncidentCountSchema)
     @tuning_page
     def get(self, args):
         return self._get(args)

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -1,5 +1,5 @@
 from webargs.flaskparser import use_args
-from flask_apispec import marshal_with, doc
+import flask_apispec as swagger
 
 from crime_data.common import cdemodels, marshmallow_schemas, models
 from crime_data.common.base import CdeResource, tuning_page
@@ -18,9 +18,12 @@ class IncidentsList(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
-    @doc(tags=['incidents'],
-         description="Return all matching incidents. Queries can drill down on specific values for fields within the incidents record.")
-    @marshal_with(marshmallow_schemas.IncidentsListResponseSchema)
+    @swagger.doc(tags=['incidents'],
+                 description=('Return all matching incidents. Queries can drill down '
+                              'on specific values for fields within the incidents record.')
+    )
+    @swagger.use_kwargs(marshmallow_schemas.ArgumentsSchema, apply=False, locations=['query'])
+    @swagger.marshal_with(marshmallow_schemas.IncidentsListResponseSchema, apply=False)
     @tuning_page
     def get(self, args):
         return self._get(args)
@@ -33,9 +36,10 @@ class IncidentsDetail(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
-    @marshal_with(marshmallow_schemas.IncidentsDetailResponseSchema)
-    @doc(tags=['incidents'],
-         description="Return the specific record for a single incident")
+    @swagger.use_kwargs(marshmallow_schemas.ArgumentsSchema, apply=False, locations=['query'])
+    @swagger.marshal_with(marshmallow_schemas.IncidentsDetailResponseSchema, apply=False)
+    @swagger.doc(tags=['incidents'],
+                 description='Return the specific record for a single incident')
     @tuning_page
     def get(self, args, nbr):
         self.verify_api_key(args)
@@ -48,8 +52,14 @@ class IncidentsCount(CdeResource):
     is_groupable = True
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
-    @doc(tags=['incidents'],
-         description="Returns counts by year for incidents. Incidents can be grouped for counting with the `by` parameter")
+    @swagger.use_kwargs(marshmallow_schemas.GroupableArgsSchema,
+                        locations=["query"],
+                        apply=False)
+    @swagger.doc(tags=['incidents'],
+                 description=('Returns counts by year for incidents. '
+                              'Incidents can be grouped for counting with the `by` parameter')
+    )
+    @swagger.marshal_with(marshmallow_schemas.IncidentCountSchema, apply=False)
     @tuning_page
     def get(self, args):
         return self._get(args)

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -1,5 +1,5 @@
 from webargs.flaskparser import use_args
-from flask_apispec import marshal_with, doc
+import flask_apispec as swagger
 
 from crime_data.common import cdemodels, marshmallow_schemas
 from crime_data.common.base import CdeResource
@@ -11,9 +11,10 @@ class OffensesList(CdeResource):
     schema = marshmallow_schemas.CrimeTypeSchema(many=True)
 
     @use_args(ArgumentsSchema)
-    @marshal_with(marshmallow_schemas.OffensesListResponseSchema)
-    @doc(tags=["offenses"],
-         description="Returns a list of all offenses.")
+    @swagger.use_kwargs(ArgumentsSchema, apply=False, locations=['query'])
+    @swagger.marshal_with(marshmallow_schemas.OffensesListResponseSchema, apply=False)
+    @swagger.doc(tags=['offenses'],
+                 description='Returns a list of all offenses.')
     def get(self, args):
         self.verify_api_key(args)
         result = cdemodels.CdeCrimeType.query

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -1,4 +1,5 @@
 from webargs.flaskparser import use_args
+from flask_apispec import marshal_with, doc
 
 from crime_data.common import cdemodels, marshmallow_schemas
 from crime_data.common.base import CdeResource
@@ -10,6 +11,9 @@ class OffensesList(CdeResource):
     schema = marshmallow_schemas.CrimeTypeSchema(many=True)
 
     @use_args(ArgumentsSchema)
+    @marshal_with(marshmallow_schemas.OffensesListResponseSchema)
+    @doc(tags=["offenses"],
+         description="Returns a list of all offenses.")
     def get(self, args):
         self.verify_api_key(args)
         result = cdemodels.CdeCrimeType.query

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -50,3 +50,5 @@ sqltap==0.3.10
 flask-marshmallow==0.7.0
 marshmallow-sqlalchemy==0.12.0
 webargs==1.4.0
+
+flask-apispec

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,6 +9,7 @@ Werkzeug==0.11.4
 Jinja2==2.8
 itsdangerous==0.24
 click>=5.0
+flask-httpauth
 
 # Database
 Flask-SQLAlchemy==2.1

--- a/tests/functional/test_incidents.py
+++ b/tests/functional/test_incidents.py
@@ -281,7 +281,7 @@ class TestIncidentsCountEndpoint:
         res = testapp.get('/incidents/count/')
         assert res.status_code == 200
 
-    def test_incidents_endpoint_includes_metadata(self, testapp):
+    def test_incidents_count_endpoint_includes_metadata(self, testapp):
         res = testapp.get('/incidents/count/')
         assert 'pagination' in res.json
 


### PR DESCRIPTION
This is using the [flask-apispec] library. Note that this is not _pretty_ Swagger for developers yet, the basic idea is to give the frontend team something to use so they can play with the API a little before it gets too far into yak-shaving territory. Right now I have the following parts done:

- [X] HTTP Auth protection for swagger endpoints
- [X] Support for `*Detail` and `*List` API endpoints
- [x] Support for `*Count` endpoints
- [X] ~Better annotation of specific fields in the return schema (descriptions)~ (see #184)
- [X] ~Better annotation of all supported arguments for the keywords (ie, showing you can do things like `victim.age_code`)~ (deferred, see #186)

Not all of these need to be done in this sprint and most of these can wait for future sprints, when it's time to be more public-facing