### PR TITLE
Remove pep8 from CodeClimate for now

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,8 +11,6 @@ engines:
           python_version: 3
   fixme:
     enabled: true
-  pep8:
-    enabled: true
   radon:
     enabled: true
 ratings:


### PR DESCRIPTION
It seems like a good idea in principle, but right now it just means our commits have something like 83 violations in CodeClimate.

![wip__basic_swagger_generation_from_the_code_by_harrisj_ _pull_request__178_ _18f_crime-data-api](https://cloud.githubusercontent.com/assets/2044/21125925/f27ae4e4-c0b6-11e6-9292-5e09cc03b99d.jpg)

The issue is that PEP8 wants us to add things like docstrings for all public methods and classes and such. I wonder if this is more of a pain than is helpful