### PR TITLE
Add a /meta/* endpoint to the API

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -15,6 +15,7 @@ import crime_data.resources.incidents
 import crime_data.resources.offenses
 import crime_data.resources.codes
 import crime_data.resources.arson
+import crime_data.resources.meta
 
 from crime_data import commands
 from crime_data.assets import assets
@@ -133,6 +134,7 @@ def add_resources(app):
     api.add_resource(crime_data.resources.arrests.ArrestsCountByAgeSex,
                      '/arrests/age_sex/')
     api.add_resource(crime_data.resources.arson.ArsonCountResource, '/arson/')
+    api.add_resource(crime_data.resources.meta.MetaDetail, '/meta/<path:endpoint>')
 
     # Wrap swagger in HTTP Auth. Can be removed after ATO
     from flask_httpauth import HTTPBasicAuth

--- a/crime_data/resources/meta.py
+++ b/crime_data/resources/meta.py
@@ -1,0 +1,53 @@
+from flask import jsonify
+from webargs.flaskparser import use_args
+import flask_apispec as swagger
+from marshmallow import fields, Schema
+from crime_data.common import cdemodels, marshmallow_schemas
+from crime_data.common.marshmallow_schemas import ma
+from crime_data.common.base import CdeResource
+
+
+class FilterColumnSchema(Schema):
+    """The schema for a specific filter that can be used"""
+
+    name = fields.String()
+    type = fields.String()
+    format = fields.String()
+    maxLength = fields.Integer()
+
+
+class MetaDetailResponseSchema(Schema):
+    """The format for responses from the meta API endpoint"""
+
+    endpoint = fields.String()
+    filters = ma.Nested(FilterColumnSchema, many=True)
+
+
+FAMILIES = {
+    'incidents': cdemodels.IncidentTableFamily(),
+    'incidents/count': cdemodels.IncidentCountTableFamily(),
+    'arson': cdemodels.ArsonTableFamily(),
+    'arrests/race': cdemodels.ArrestsByRaceTableFamily(),
+    'arrests/ethnicity': cdemodels.ArrestsByEthnicityTableFamily(),
+    'arrests/age_sex': cdemodels.ArrestsByAgeSexTableFamily()
+}
+
+
+class MetaDetail(CdeResource):
+    """The meta API endpoint returns information about the API endpoint
+    that follows it. Currently this is just the allowed filters for
+    the endpoint.
+    """
+
+    @swagger.use_kwargs({'endpoint': fields.Str()})
+    @swagger.marshal_with(MetaDetailResponseSchema)
+    @swagger.doc(tags=['meta'],
+                 description=('Returns meta information about the query endpoint. '
+                              'Currently, this is mainly a list of filters that can '
+                              'be added to queries.'))
+    def get(self, endpoint):
+        out = {
+            'endpoint': endpoint,
+            'filters': FAMILIES[endpoint].filter_columns
+        }
+        return jsonify(out)

--- a/tests/functional/test_meta.py
+++ b/tests/functional/test_meta.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Functional tests using WebTest.
+
+See: http://webtest.readthedocs.org/
+"""
+import pytest
+from crime_data.resources.meta import FAMILIES
+
+class TestCodesEndpoint:
+    @pytest.mark.parametrize('endpoint', FAMILIES)
+    def test_meta_endpoint_exists(self, testapp, endpoint):
+        res = testapp.get('/meta/{0}'.format(endpoint))
+        assert res.status_code == 200
+
+        assert 'filters' in res.json
+        assert res.json['filters'] == FAMILIES[endpoint].filter_columns


### PR DESCRIPTION
Fixes #198

A call for /meta/incidents/count will return information about the incidents/count API endpoint, mainly what the filter columns you can present to either the main query string or also to the `by` or `fields` arguments in a query string. I don't have them for everything yet, just those functions that use the TableFamily classes and subclasses (so it seems like `offenses` doesn't have this)

Note: this has a functional integration test for the endpoint, but it probably should ideally also have a unit test for the change to the `cdemodels.TableFamily` class. We don't seem to have any unit tests for sub-API-response classes yet though, so we need to add those as another task I think.