### PR TITLE
Add logic to run full count query when estimates aren't required.

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -363,6 +363,8 @@ class CdeResource(MethodResource):
                 if count < COUNT_QUERY_THRESHOLD:
                     # If the count is less than 
                     count = results.count()
+            else:
+                count = results.count()
         except Exception as count_exception:
             # Fallback to counting results with extra query.
             current_app.logger.warning('Failed to fast_count rows:')


### PR DESCRIPTION
Added another branch to run full count query if no exception was thrown, AND count_estimated is not required