### PR TITLE
Meta endpoint ignores trailing slashes

### DIFF
--- a/crime_data/resources/meta.py
+++ b/crime_data/resources/meta.py
@@ -34,7 +34,8 @@ FAMILIES = {
 
 
 class MetaDetail(CdeResource):
-    """The meta API endpoint returns information about the API endpoint
+    """
+    The meta API endpoint returns information about the API endpoint
     that follows it. Currently this is just the allowed filters for
     the endpoint.
     """
@@ -46,6 +47,7 @@ class MetaDetail(CdeResource):
                               'Currently, this is mainly a list of filters that can '
                               'be added to queries.'))
     def get(self, endpoint):
+        endpoint = endpoint.rstrip('/')
         out = {
             'endpoint': endpoint,
             'filters': FAMILIES[endpoint].filter_columns

--- a/tests/functional/test_meta.py
+++ b/tests/functional/test_meta.py
@@ -14,3 +14,8 @@ class TestCodesEndpoint:
 
         assert 'filters' in res.json
         assert res.json['filters'] == FAMILIES[endpoint].filter_columns
+
+
+    def test_meta_endpoint_handles_trailing_slash(self, testapp):
+        res = testapp.get('/meta/incidents/')
+        assert res.status_code == 200


### PR DESCRIPTION
This way something like `meta/incidents/` works