### PR TITLE
Bandit was triggering on New Relic error handling

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -187,5 +187,5 @@ def register_newrelic(app):
         settings = newrelic.agent.global_settings()
         settings.license_key = license_key
         newrelic.agent.initialize()
-    except:
+    except: #nosec
         pass


### PR DESCRIPTION
I think this code is fine, so I added a #nosec to ignore. I am not sure why `bandit` did not fail when run on the PR, but I will have to investigate. This might mean a change to the circle config