### PR TITLE
Add state and county demographics endpoints

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -2,12 +2,10 @@
 """The app module, containing the app factory function."""
 import csv
 import io
-import json
 from os import getenv
 
 import flask_restful as restful
 from flask import Flask, render_template
-from flask_cors import CORS, cross_origin
 
 import crime_data.resources.agencies
 import crime_data.resources.arrests
@@ -20,6 +18,7 @@ import crime_data.resources.offenders
 import crime_data.resources.victims
 import crime_data.resources.cargo_theft
 import crime_data.resources.hate_crime
+import crime_data.resources.geo
 
 from crime_data import commands
 from crime_data.assets import assets
@@ -31,7 +30,7 @@ from flask_apispec.extension import FlaskApiSpec
 from crime_data.settings import ProdConfig
 
 if __name__ == '__main__':
-    app.run(debug=True) #nosec, this isn't called on production
+    app.run(debug=True)  # nosec, this isn't called on production
 
 
 def create_app(config_object=ProdConfig):
@@ -41,7 +40,6 @@ def create_app(config_object=ProdConfig):
     """
     app = Flask(__name__)
     app.config.from_object(config_object)
-    CORS(app)
     register_extensions(app)
     register_blueprints(app)
     register_errorhandlers(app)
@@ -141,8 +139,14 @@ def add_resources(app):
                      '/arrests/ethnicity/')
     api.add_resource(crime_data.resources.arrests.ArrestsCountByAgeSex,
                      '/arrests/age_sex/')
-    api.add_resource(crime_data.resources.arson.ArsonCountResource, '/arson/')
-    api.add_resource(crime_data.resources.meta.MetaDetail, '/meta/<path:endpoint>')
+    api.add_resource(crime_data.resources.arson.ArsonCountResource,
+                     '/arson/')
+    api.add_resource(crime_data.resources.meta.MetaDetail,
+                     '/meta/<path:endpoint>')
+    api.add_resource(crime_data.resources.geo.StateDetail,
+                     '/geo/states/<string:id>')
+    api.add_resource(crime_data.resources.geo.CountyDetail,
+                     '/geo/counties/<string:fips>')
 
     api.add_resource(crime_data.resources.offenders.OffendersCountStates, '/offenders/count/states/<int:state_id>/<string:variable>')
     api.add_resource(crime_data.resources.victims.VictimsCountStates, '/victims/count/states/<int:state_id>/<string:variable>')
@@ -197,6 +201,9 @@ def add_resources(app):
     docs.register(crime_data.resources.arrests.ArrestsCountByRace)
     docs.register(crime_data.resources.arrests.ArrestsCountByEthnicity)
     docs.register(crime_data.resources.arrests.ArrestsCountByAgeSex)
+    docs.register(crime_data.resources.meta.MetaDetail)
+    docs.register(crime_data.resources.geo.StateDetail)
+    docs.register(crime_data.resources.geo.CountyDetail)
 
 
 def newrelic_status_endpoint():

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -231,7 +231,7 @@ class RefDivisionSchema(ma.ModelSchema):
 class RefStateSchema(ma.ModelSchema):
     class Meta:
         model = models.RefState
-        exclude = ('state_id', )
+        exclude = ('state_id', 'counties')
 
     division = ma.Nested(RefDivisionSchema)
 

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -838,3 +838,56 @@ class ArsonCountResponseSchema(PaginatedResponseSchema):
 
 class CodeIndexResponseSchema(Schema):
     key = marsh_fields.String()
+
+
+class StateCountyResponseSchema(ma.ModelSchema):
+    """Schema for counties in the StateDetail response."""
+
+    class Meta:
+        model = cdemodels.CdeRefCounty
+        fields = ('county_id', 'county_name', 'fips', 'population', )
+
+    fips = marsh_fields.String()
+    population = marsh_fields.Integer()
+
+
+class StateDetailResponseSchema(ma.ModelSchema):
+    """Response schema for the StateDetail API method."""
+
+    class Meta:
+        model = cdemodels.CdeRefState
+        ordered = True
+        fields = ('state_id', 'name', 'postal_abbr', 'fips_code',
+                  'population', 'num_agencies', 'police_officers', 'counties', )
+
+    name = marsh_fields.String(attribute='state_name')
+    postal_abbr = marsh_fields.String(attribute='state_postal_abbr')
+    fips_code = marsh_fields.String(attribute='state_fips_code')
+    population = marsh_fields.Integer()
+    num_agencies = marsh_fields.Integer()
+    police_officers = marsh_fields.Integer()
+
+    # This is not the most efficient, since it's a N queries for population, but
+    # that is something we can fix later if a problem
+    counties = ma.Nested(StateCountyResponseSchema,
+                         attribute='counties',
+                         many=True)
+
+
+class CountyDetailResponseSchema(ma.ModelSchema):
+    """Response schema for the CountyDetail method."""
+
+    class Meta:
+        model = cdemodels.CdeRefCounty
+        ordered = True
+        fields = ('county_id', 'county_name',
+                  'fips', 'population',
+                  'num_agencies', 'police_officers',
+                  'state_name', 'state_abbr', )
+
+    fips = marsh_fields.String()
+    population = marsh_fields.Integer()
+    num_agencies = marsh_fields.Integer()
+    police_officers = marsh_fields.Integer()
+    state_name = marsh_fields.String()
+    state_abbr = marsh_fields.String()

--- a/crime_data/common/models.py
+++ b/crime_data/common/models.py
@@ -2071,6 +2071,26 @@ class RefCountyPopulation(db.Model):
     county = db.relationship('RefCounty')
 
 
+class RefStatePopulation(db.Model):
+    __tablename__ = 'ref_state_population'
+    __tableargs__ = (UniqueConstraint('state_id', 'data_year'), )
+
+    state_id = db.Column(db.Integer,
+                         db.ForeignKey('ref_state.state_id',
+                                       deferrable=True,
+                                       initially='DEFERRED'),
+                         nullable=False,
+                         index=True,
+                         primary_key=True)
+    data_year = db.Column(db.SmallInteger, nullable=False, primary_key=True)
+    population = db.Column(db.BigInteger)
+    source_flag = db.Column(db.String(1), nullable=False)
+    census = db.Column(db.BigInteger)
+    change_timestamp = db.Column(db.DateTime(True))
+    change_user = db.Column(db.String(100))
+    reporting_population = db.Column(db.BigInteger)
+
+
 class RefDepartment(db.Model):
     __tablename__ = 'ref_department'
 

--- a/crime_data/common/models.py
+++ b/crime_data/common/models.py
@@ -2324,7 +2324,9 @@ class RefState(db.Model):
                             index=True)
 
     division = db.relationship('RefDivision', lazy=False)
-    counties = db.relationship('RefCounty', lazy='dynamic', back_populates='state')
+    counties = db.relationship('RefCounty',
+                               lazy='dynamic',
+                               back_populates='state')
 
 
 class RefSubmittingAgency(db.Model):

--- a/crime_data/common/models.py
+++ b/crime_data/common/models.py
@@ -1725,6 +1725,29 @@ class OffenseClassification(db.Model):
     class_sort_order = db.Column(db.SmallInteger)
 
 
+class PeEmployeeData(db.Model):
+    __tablename__ = 'pe_employee_data'
+    __table_args__ = (UniqueConstraint('agency_id', 'data_year'), )
+
+    agency_id = db.Column(db.Integer,
+                          db.ForeignKey('ref_agency.agency_id',
+                                        deferrable=True,
+                                        initially='DEFERRED'),
+                          nullable=False,
+                          index=True,
+                          primary_key=True)
+    data_year = db.Column(db.SmallInteger, nullable=False, primary_key=True)
+    reported_flag = db.Column(db.String(1))
+    male_officer = db.Column(db.Integer)
+    male_civilian = db.Column(db.Integer)
+    male_total = db.Column(db.Integer)
+    female_officer = db.Column(db.Integer)
+    female_civilian = db.Column(db.Integer)
+    female_total = db.Column(db.Integer)
+    officer_rate = db.Column(db.Integer)
+    civilian_rate = db.Column(db.Integer)
+
+
 class RefAgencyCounty(db.Model):
     __tablename__ = 'ref_agency_county'
     __table_args__ = (UniqueConstraint('agency_id', 'county_id',
@@ -1848,6 +1871,7 @@ class RefAgency(db.Model):
     tribe = db.relationship('RefTribe')
     counties = db.relationship('RefCounty',
                                secondary=RefAgencyCounty.__table__,
+
                                collection_class=set)
 
 
@@ -2023,18 +2047,14 @@ class RefCounty(db.Model):
                          nullable=False,
                          index=True)
 
-    state = db.relationship('RefState')
+    state = db.relationship('RefState', back_populates='counties')
 
 
 class RefCountyPopulation(db.Model):
     __tablename__ = 'ref_county_population'
     __table_args__ = (UniqueConstraint('county_id', 'data_year'), )
 
-    id = db.Column(db.Integer,
-                   primary_key=True,
-                   server_default=text(
-                       "nextval('ref_county_population_id_seq'::regclass)"))
-    data_year = db.Column(db.SmallInteger, nullable=False)
+    data_year = db.Column(db.SmallInteger, nullable=False, primary_key=True)
     population = db.Column(db.BigInteger)
     source_flag = db.Column(db.String(1), nullable=False)
     change_timestamp = db.Column(db.DateTime(True))
@@ -2045,7 +2065,8 @@ class RefCountyPopulation(db.Model):
                                         deferrable=True,
                                         initially='DEFERRED'),
                           nullable=False,
-                          index=True)
+                          index=True,
+                          primary_key=True)
 
     county = db.relationship('RefCounty')
 
@@ -2283,6 +2304,7 @@ class RefState(db.Model):
                             index=True)
 
     division = db.relationship('RefDivision', lazy=False)
+    counties = db.relationship('RefCounty', lazy='dynamic', back_populates='state')
 
 
 class RefSubmittingAgency(db.Model):

--- a/crime_data/resources/geo.py
+++ b/crime_data/resources/geo.py
@@ -1,0 +1,32 @@
+from flask import jsonify
+import flask_apispec as swagger
+from webargs.flaskparser import use_args
+
+from marshmallow import fields
+from crime_data.common import cdemodels, marshmallow_schemas, models
+from crime_data.common.base import CdeResource, tuning_page
+
+
+class StateDetail(CdeResource):
+    schema = marshmallow_schemas.StateDetailResponseSchema()
+
+    @use_args(marshmallow_schemas.ArgumentsSchema)
+    @swagger.marshal_with(marshmallow_schemas.StateDetailResponseSchema, apply=False)
+    @swagger.doc(tags=['geo'],
+                 description=['Returns basic information about a state and lists counties in the state'])
+    def get(self, args, id):
+        self.verify_api_key(args)
+        state = cdemodels.CdeRefState.get(abbr=id).one()
+        return jsonify(self.schema.dump(state).data)
+
+
+class CountyDetail(CdeResource):
+    schema = marshmallow_schemas.CountyDetailResponseSchema()
+
+    @use_args(marshmallow_schemas.ArgumentsSchema)
+    @swagger.marshal_with(marshmallow_schemas.CountyDetailResponseSchema, apply=False)
+    @swagger.doc(tags=['geo'], description='Demographic details for a county')
+    def get(self, args, fips):
+        self.verify_api_key(args)
+        county = cdemodels.CdeRefCounty.get(fips=fips).one()
+        return jsonify(self.schema.dump(county).data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from webtest import TestApp
 from crime_data.app import create_app
 from crime_data.database import db as _db
 from crime_data.settings import TestConfig
-
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 @pytest.yield_fixture(scope='function')
 def app():
@@ -28,14 +28,12 @@ def testapp(app):
 
 
 @pytest.yield_fixture(scope='function')
-def db(app):
+def rollback(app):
     """A database for the tests."""
     _db.app = app
-    with app.app_context():
-        _db.create_all()
+    _db.session.begin(subtransactions=True)
 
     yield _db
 
     # Explicitly close DB connection
-    _db.session.close()
-    _db.drop_all()
+    _db.session.rollback()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """Factories to help in tests."""
-from factory import PostGenerationMethodCall, Sequence
+from factory import PostGenerationMethodCall, Sequence, LazyAttribute, SubFactory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from crime_data.database import db
+from crime_data.common import models as m
+from tests import conftest
 
 class BaseFactory(SQLAlchemyModelFactory):
     """Base factory."""
@@ -12,4 +14,42 @@ class BaseFactory(SQLAlchemyModelFactory):
         """Factory configuration."""
 
         abstract = True
+#        sqlalchemy_session = conftest.Session
         sqlalchemy_session = db.session
+        force_flush = True
+
+
+class RefCountyFactory(BaseFactory):
+
+    class Meta:
+        model = m.RefCounty
+
+    county_id = Sequence(lambda n: n+10000)
+    state_id = 31 # Nebraska
+
+
+class RefAgencyFactory(BaseFactory):
+
+    class Meta:
+        model = m.RefAgency
+
+    agency_id = Sequence(lambda n: n+10000)
+    ori = Sequence(lambda n: 'ZZ%07d' % n)
+    legacy_ori = LazyAttribute(lambda obj: obj.ori)
+    ucr_agency_name = Sequence(lambda n: 'Factory Agency %0d' % n)
+    ncic_agency_name = LazyAttribute(lambda obj: obj.ucr_agency_name)
+    state_id = 31 # Nebraska
+    agency_type_id = 1 # City
+    agency_status = 'A'
+    population_family_id = 2 # City
+
+
+class RefAgencyCountyFactory(BaseFactory):
+
+    class Meta:
+        model = m.RefAgencyCounty
+
+    data_year = 2014
+    agency = SubFactory(RefAgencyFactory)
+    county = SubFactory(RefCountyFactory)
+    metro_div_id = 411 # Not Specified

--- a/tests/functional/test_geo.py
+++ b/tests/functional/test_geo.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Functional tests using WebTest.
+
+See: http://webtest.readthedocs.org/
+"""
+
+class TestGeoEndpoint:
+    def test_state_detail_endpoint(self, testapp):
+        res = testapp.get('/geo/states/WY')
+        assert res.status_code == 200
+
+    def test_county_detail_endpoint(self, testapp):
+        res = testapp.get('/geo/counties/39043')
+        assert res.status_code == 200

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from crime_data.common.cdemodels import CdeRefState, CdeRefCounty
+from crime_data.common.models import RefCounty
+from crime_data.common.cdemodels import *
+from tests.factories import *
 import pytest
 
 class TestCdeRefState:
@@ -19,8 +21,8 @@ class TestCdeRefState:
 
 class TestCdeRefCounty:
     def test_get_by_id(self, testapp):
-        s = CdeRefCounty.get(county_id=123).one()
-        assert s.county_name == 'DREW'
+        s = CdeRefCounty.get(county_id=753).one()
+        assert s.county_name == 'KENDALL'
 
     def test_get_by_fips(self, testapp):
         s = CdeRefCounty.get(fips='06075').one()
@@ -43,3 +45,26 @@ class TestCdeRefCounty:
 
         county = CdeRefCounty(county_fips_code='7', state=state)
         assert county.fips == '02007'
+
+    def test_num_agencies(self, app):
+        """Using the test data in the ref_agencies table"""
+
+        county = CdeRefCounty.get(county_id=2271).one()
+        assert county.num_agencies_for_year(2014) == 8
+
+    def test_population(self, app):
+        """Using the test data in the ref_county_population table"""
+
+        county = CdeRefCounty.get(county_id=74).one()
+        assert county.population_for_year(1960) == 24501
+
+    def test_police_officers(self, app):
+        """Using the test data in the database"""
+
+        county = CdeRefCounty.get(county_id=3015).one()
+        assert county.police_officers_for_year(1977) == 19
+
+
+class TestCdeRefAgencyCounty:
+    def test_current_year(self, testapp):
+        assert CdeRefAgencyCounty.current_year() == 2016

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -68,3 +68,19 @@ class TestCdeRefCounty:
 class TestCdeRefAgencyCounty:
     def test_current_year(self, testapp):
         assert CdeRefAgencyCounty.current_year() == 2016
+
+
+class TestCdeRefState:
+    """Test the CdeRefState class"""
+
+    def test_population(self, app):
+        state = CdeRefState.get(abbr="WY").one()
+        assert state.population_for_year(1984) == 511000
+
+    def test_num_agencies(self, app):
+        state = CdeRefState.get(abbr='VA').one()
+        assert state.num_agencies == 145
+
+    def test_police_officers(self, app):
+        state = CdeRefState.get(abbr="VA").one()
+        assert state.police_officers_for_year(2008) == 48

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from crime_data.common.cdemodels import CdeRefState, CdeRefCounty
+import pytest
+
+class TestCdeRefState:
+    def test_get_by_id(self, testapp):
+        s = CdeRefState.get(state_id=12).one()
+        assert s.state_name == 'Florida'
+
+    def test_get_by_abbr(self, testapp):
+        s = CdeRefState.get(abbr='NE').one()
+        assert s.state_name == 'Nebraska'
+
+    def test_get_by_fips(self, testapp):
+        s = CdeRefState.get(fips='06075').one()
+        assert s.state_name == 'California'
+
+
+class TestCdeRefCounty:
+    def test_get_by_id(self, testapp):
+        s = CdeRefCounty.get(county_id=123).one()
+        assert s.county_name == 'DREW'
+
+    def test_get_by_fips(self, testapp):
+        s = CdeRefCounty.get(fips='06075').one()
+        assert s.county_name == 'SAN FRANCISCO'
+
+        with pytest.raises(ValueError):
+            CdeRefCounty.get(fips='6075')
+
+        with pytest.raises(ValueError):
+            CdeRefCounty.get(fips=6075)
+
+    def test_get_by_name(self, testapp):
+        s = CdeRefCounty.get(name='San Francisco').one()
+        assert s.county_name == 'SAN FRANCISCO'
+
+    def test_fips_property(self, testapp):
+        state = CdeRefState(state_fips_code='02')
+        county = CdeRefCounty(county_fips_code='343', state=state)
+        assert county.fips == '02343'
+
+        county = CdeRefCounty(county_fips_code='7', state=state)
+        assert county.fips == '02007'

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -52,11 +52,23 @@ class TestCdeRefCounty:
         county = CdeRefCounty.get(county_id=2271).one()
         assert county.num_agencies_for_year(2014) == 8
 
+    def test_num_agencies_missing_data(self, app):
+        """This county is missing current agencies data"""
+
+        county = CdeRefCounty.get(county_id=2271).one()
+        assert county.num_agencies is None
+
     def test_population(self, app):
         """Using the test data in the ref_county_population table"""
 
         county = CdeRefCounty.get(county_id=74).one()
         assert county.population_for_year(1960) == 24501
+
+    def test_population_missing_data(self, app):
+        """This county is missing current population data"""
+
+        county = CdeRefCounty.get(county_id=74).one()
+        assert county.population is None
 
     def test_police_officers(self, app):
         """Using the test data in the database"""
@@ -64,6 +76,11 @@ class TestCdeRefCounty:
         county = CdeRefCounty.get(county_id=3015).one()
         assert county.police_officers_for_year(1977) == 19
 
+    def test_police_officers_missing_data(self, app):
+
+        county = CdeRefCounty.get(county_id=3015).one()
+        assert county.police_officers_for_year(2021) is None
+        assert county.police_officers is None
 
 class TestCdeRefAgencyCounty:
     def test_current_year(self, testapp):


### PR DESCRIPTION
Fixes #279 

This will be code to return demographic information for states (called by postal code) or counties (called by FIPS code) from the database.

I did this PR as an experiment of adding methods to the base SQLAlchemy classes by using new CdeRefState and CdeRefCounty classes. This way if the `models.py` file is regenerated, that functionality is supposed to still be there. 

I do wonder though if we should consider some way to monkey patch the existing classes rather than defining new wrappers, because there was one point where SqlAlchemy was confused and didn't know whether to instantiate a RefCounty or CdeRefCounty object on a back reference. The idea would be to not let people import from `crime_data.common.models`. Instead everybody would import from `crime_data.common.cdemodels` where we would import * from the `models` file and monkeypatch classes with added methods but keep the same name (so instead of CdeRefState, it would just be adding methods to RefState). Thoughts?