### PR TITLE
Disable pep8 checking for CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,7 +12,7 @@ engines:
   fixme:
     enabled: true
   pep8:
-    enabled: true
+    enabled: false
   radon:
     enabled: true
 ratings:


### PR DESCRIPTION
It's a good aspiration, but the pep8 checking is turning into a real hassle for our process at the moment. Can reenable when we have more capacity down the road.