### PR TITLE
Remove HTTP auth protection for Swagger

### DIFF
--- a/api_support_notes.md
+++ b/api_support_notes.md
@@ -1,25 +1,51 @@
-
 Available fields for API
 ========================
 
-Hopefully these will soon all be visible in https://crime-data-api.fr.cloud.gov/docs/.
-However, until then...
+The Crime Data API is what powers the CDE website (whose code is
+at
+[crime-data-explorer](https://github.com/18f/crime-data-explorer). All
+API requests require an API key which can be provided to you securely
+by a FBI CDE team member.
+
+All API endpoints are documented in Swagger, and interactive
+documentation can be found at [https://crime-data-api.fr.cloud.gov/swagger-ui/](https://crime-data-api.fr.cloud.gov/swagger-ui/)
+
+Note that this documentation is still not feature-complete. Many
+fields are missing descriptions and the documentation will focus
+primarily on what the frontend developers on the FBI project need
+before making the documentation more accessible. This document is a
+supplement to the Swagger documentation with some general notes about
+API usage.
 
 /incidents/
 -----------
 
-You can filter by any field in the results of an /incidents/ query.
+This is the endpoint used to query specific records from NIBRS. It
+should not be used to aggregate NIBRS statistics.
 
-There's a shortcut to getting those available filters for `static/swagger.json`:
-uncomment the call to `print_map` in `crime_data/common/cdemodels.py`,
-run the app, run a query against it, and copy-and-paste the terminal-window
-output into `swagger.json`.
+You can filter by any field in the results of an `/incidents/` query by
+appending values to the query string in the API call. The
+`/meta/incidents` API endpoint returns a list of fields that can be
+filtered on. In some cases, fields might be codes within the FBI
+database (ie, `state_id` or `offense_type_code`). To get a list of
+those possible values, look for one of the endpoints listed in the
+`/codes/` API endpoint.
+
 
 /incidents/count
 ----------------
 
-You can filter by any field listed in http://localhost:5000/offenses/;
-that summary of offenses also contains the available values.
+This is the endpoint used to query specific records from SRS aka
+"Return A" records. It should not be used to aggregate NIBRS
+statistics.
+
+You can filter by any field in the results of an `/incidents/count` query by
+appending values to the query string in the API call. The
+`/meta/incidents/count` API endpoint returns a list of fields that can be
+filtered on. In some cases, fields might be codes within the FBI
+database (ie, `state_id` or `offense_type_code`). To get a list of
+those possible values, look for one of the endpoints listed in the
+`/codes/` API endpoint.
 
 You can also filter by any field in `agencies` or its child tables
 (location, etc.); the handiest place to see these fields is in the
@@ -27,6 +53,17 @@ results of an `/incidents/` query.
 
 Including `by=field1_name,field2_name,field3_name` in the parameters will group the results by,
 and show, those field names.
+
+Other Endpoints
+---------------
+
+The `/incidents` and `/incidents/count` endpoints are essentially
+broad by design, so that they could be used to explore future
+directions for the front-end interface. This does not make them
+especially performant however, and as the CDE frontend is built, we
+will develop more specific and efficient endpoints for elements on the
+CDE pages. Your best bet is to refer to the Swagger UI for the most
+up-to-date listing on all the methods.
 
 General filtering rules
 =======================
@@ -55,7 +92,10 @@ requires!
 Pagination
 ==========
 
-App supports `page` and `per_page` arguments.
-
-Currently the reported `page_count` is a shameless, performance-preserving
-lie.  
+App supports `page` and `per_page` arguments. Note that for large
+queries, the total results returned will be a rough estimate for
+performance reasons. This means that if we were to paginate over all
+records, the total nimber of pages might be less or more than the
+reported number of pages. Queries that are estimated to return less
+than a 1000 records are then precisely counted so that will not be an
+issue for them.

--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -158,34 +158,6 @@ def add_resources(app):
     api.add_resource(crime_data.resources.hate_crime.HateCrimesCountCounties, '/hc/count/counties/<int:county_id>/<string:variable>')
     api.add_resource(crime_data.resources.hate_crime.HateCrimesCountStates, '/hc/count/states/<int:state_id>/<string:variable>')
 
-    # Wrap swagger in HTTP Auth. Can be removed after ATO
-    from flask_httpauth import HTTPBasicAuth
-    auth = HTTPBasicAuth()
-
-    @auth.get_password
-    def get_pw(username):
-        target_username = None
-        target_password = None
-
-        try:
-            target_username = get_credential('HTTP_BASIC_USERNAME')
-            target_password = get_credential('HTTP_BASIC_PASSWORD')
-        except KeyError:
-            target_username = getenv('HTTP_USERNAME')
-            target_password = getenv('HTTP_PASSWORD')
-
-        if target_username is None or target_password is None:
-            return None
-
-        if username == target_username:
-            return target_password
-
-        return None
-
-    FlaskApiSpec.swagger_json = auth.login_required(FlaskApiSpec.swagger_json)
-    FlaskApiSpec.swagger_ui = auth.login_required(FlaskApiSpec.swagger_ui)
-    # end of HTTP Auth protection for Swagger endpoints
-
     docs = FlaskApiSpec(app)
     docs.register(crime_data.resources.agencies.AgenciesDetail)
     docs.register(crime_data.resources.agencies.AgenciesList)


### PR DESCRIPTION
Since we are in ATO review now, it is okay to remove the HTTP Auth protection around the /swagger/ and /swagger-ui/ endpoints