### PR TITLE
Fix for Swagger documentation crash

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,18 +3,19 @@
 wheel==0.29.0
 
 # Flask
-Flask==0.11.1
+Flask==0.12
 MarkupSafe==0.23
-Werkzeug==0.11.4
-Jinja2==2.8
+Werkzeug==0.11.15
+Jinja2==2.9.4
 itsdangerous==0.24
 click>=5.0
 flask-httpauth
+Flask-Script>=0.6
 
 # Database
 Flask-SQLAlchemy==2.1
 psycopg2==2.6.1
-SQLAlchemy==1.0.12
+SQLAlchemy==1.1.5
 
 # Migrations
 Flask-Migrate==2.0.0
@@ -33,6 +34,7 @@ Flask-Caching>=1.0.0
 
 # Debug toolbar
 Flask-DebugToolbar==0.10.0
+IPython>=5.0.0
 
 # RESTful
 Flask-RESTful==0.3.5
@@ -41,8 +43,10 @@ Flask-RESTful==0.3.5
 sqltap==0.3.10
 newrelic
 
+marshmallow==2.10.5
 flask-marshmallow==0.7.0
-marshmallow-sqlalchemy==0.12.0
+marshmallow-sqlalchemy==0.12.1
 webargs==1.4.0
 
-flask-apispec
+apispec==0.17.1
+flask-apispec==0.3.2


### PR DESCRIPTION
The swagger documentation was failing with

> TypeError: 'bool' object is not iterable

The issue seems to be related to new versions of Marshmallow and APIspec that were released in January and that flask-apispec was not pinned to a specific version. Pinned both to an older version which resolved it.