### PR TITLE
Count views should also accept state postal codes

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -150,7 +150,8 @@ def add_resources(app):
     api.add_resource(crime_data.resources.offenses.OffensesCountNational,
                      '/offenses/count/national/<string:variable>')
     api.add_resource(crime_data.resources.offenses.OffensesCountStates,
-                     '/offenses/count/states/<int:state_id>/<string:variable>')
+                     '/offenses/count/states/<int:state_id>/<string:variable>',
+                     '/offenses/count/states/<string:state_abbr>/<string:variable>')
     api.add_resource(crime_data.resources.offenses.OffensesCountCounties,
                      '/offenses/count/counties/<string:variable>')
 
@@ -158,11 +159,14 @@ def add_resources(app):
     api.add_resource(crime_data.resources.offenders.OffendersCountNational,
                      '/offenders/count/national/<string:variable>')
     api.add_resource(crime_data.resources.offenders.OffendersCountStates,
-                     '/offenders/count/states/<int:state_id>/<string:variable>')
+                     '/offenders/count/states/<int:state_id>/<string:variable>',
+                     '/offenders/count/states/<string:state_abbr>/<string:variable>')
+
     api.add_resource(crime_data.resources.victims.VictimsCountNational,
                      '/victims/count/national/<string:variable>')
     api.add_resource(crime_data.resources.victims.VictimsCountStates,
-                     '/victims/count/states/<int:state_id>/<string:variable>')
+                     '/victims/count/states/<int:state_id>/<string:variable>',
+                     '/victims/count/states/<string:state_abbr>/<string:variable>')
     api.add_resource(crime_data.resources.offenders.OffendersCountCounties,
                      '/offenders/count/counties/<int:county_id>/<string:variable>')
     api.add_resource(crime_data.resources.victims.VictimsCountCounties,
@@ -173,25 +177,32 @@ def add_resources(app):
     api.add_resource(crime_data.resources.cargo_theft.CargoTheftsCountCounties,
                      '/ct/count/counties/<int:county_id>/<string:variable>')
     api.add_resource(crime_data.resources.cargo_theft.CargoTheftsCountStates,
-                     '/ct/count/states/<int:state_id>/<string:variable>')
+                     '/ct/count/states/<int:state_id>/<string:variable>',
+                     '/ct/count/states/<string:state_abbr>/<string:variable>')
 
     api.add_resource(crime_data.resources.hate_crime.HateCrimesCountNational,
                      '/hc/count/national/<string:variable>')
     api.add_resource(crime_data.resources.hate_crime.HateCrimesCountCounties,
                      '/hc/count/counties/<int:county_id>/<string:variable>')
     api.add_resource(crime_data.resources.hate_crime.HateCrimesCountStates,
-                     '/hc/count/states/<int:state_id>/<string:variable>')
+                     '/hc/count/states/<int:state_id>/<string:variable>',
+                     '/hc/count/states/<string:state_abbr>/<string:variable>')
+
     api.add_resource(crime_data.resources.victims.VictimOffenseSubcounts,
                      '/victims/count/states/<int:state_id>/<string:variable>/offenses',
+                     '/victims/count/states/<string:state_abbr>/<string:variable>/offenses',
                      '/victims/count/national/<string:variable>/offenses')
     api.add_resource(crime_data.resources.offenders.OffenderOffenseSubcounts,
                      '/offenders/count/states/<int:state_id>/<string:variable>/offenses',
+                     '/offenders/count/states/<string:state_abbr>/<string:variable>/offenses',
                      '/offenders/count/national/<string:variable>/offenses')
     api.add_resource(crime_data.resources.hate_crime.HateCrimeOffenseSubcounts,
                      '/hc/count/states/<int:state_id>/<string:variable>/offenses',
+                     '/hc/count/states/<string:state_abbr>/<string:variable>/offenses',
                      '/hc/count/national/<string:variable>/offenses')
     api.add_resource(crime_data.resources.cargo_theft.CargoTheftOffenseSubcounts,
                      '/ct/count/states/<int:state_id>/<string:variable>/offenses',
+                     '/ct/count/states/<string:state_abbr>/<string:variable>/offenses',
                      '/ct/count/national/<string:variable>/offenses')
 
     docs = FlaskApiSpec(app)

--- a/crime_data/resources/cargo_theft.py
+++ b/crime_data/resources/cargo_theft.py
@@ -34,9 +34,9 @@ class CargoTheftsCountStates(CdeResource):
             'Offender Incidents - By State'))
     @swagger.marshal_with(marshmallow_schemas.IncidentCountSchema, apply=False)
     @tuning_page
-    def get(self, args, state_id, variable):
+    def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
-        model = cdemodels.CargoTheftCountView(variable, year=args['year'], state_id=state_id)
+        model = cdemodels.CargoTheftCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
 
@@ -114,11 +114,12 @@ class CargoTheftOffenseSubcounts(CdeResource):
              'Victim Incidents - By county'))
     @swagger.marshal_with(marshmallow_schemas.OffenseCargoTheftCountViewResponseSchema, apply=False)
     @tuning_page
-    def get(self, args, variable, state_id=None):
+    def get(self, args, variable, state_id=None, state_abbr=None):
         self.verify_api_key(args)
         model = cdemodels.OffenseCargoTheftCountView(variable,
                                                      year=args.get('year', None),
                                                      offense_name=args.get('offense_name', None),
-                                                     state_id=state_id)
+                                                     state_id=state_id,
+                                                     state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)

--- a/crime_data/resources/hate_crime.py
+++ b/crime_data/resources/hate_crime.py
@@ -35,9 +35,9 @@ class HateCrimesCountStates(CdeResource):
             'Hate Crime Incidents - By State'))
     @swagger.marshal_with(marshmallow_schemas.IncidentCountSchema, apply=False)
     @tuning_page
-    def get(self, args, state_id, variable):
+    def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
-        model = cdemodels.HateCrimeCountView(variable, year=args['year'], state_id=state_id)
+        model = cdemodels.HateCrimeCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
 
@@ -111,11 +111,13 @@ class HateCrimeOffenseSubcounts(CdeResource):
              'Hate crime incidents - By county'))
     @swagger.marshal_with(marshmallow_schemas.OffenseCountViewResponseSchema, apply=False)
     @tuning_page
-    def get(self, args, variable, state_id=None):
+    def get(self, args, variable, state_id=None, state_abbr=None):
         self.verify_api_key(args)
+
         model = cdemodels.OffenseHateCrimeCountView(variable,
                                                     year=args.get('year', None),
                                                     offense_name=args.get('offense_name', None),
-                                                    state_id=state_id)
+                                                    state_id=state_id,
+                                                    state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)

--- a/crime_data/resources/offenders.py
+++ b/crime_data/resources/offenders.py
@@ -60,9 +60,9 @@ class OffendersCountStates(CdeResource):
             'Offender Incidents - By State'))
     @swagger.marshal_with(marshmallow_schemas.IncidentCountSchema, apply=False)
     @tuning_page
-    def get(self, args, state_id, variable):
+    def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
-        model = cdemodels.OffenderCountView(variable, year=args['year'], state_id=state_id)
+        model = cdemodels.OffenderCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
 

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -75,9 +75,9 @@ class OffensesCountStates(CdeResource):
             'Offense incidents - By State'))
     @swagger.marshal_with(marshmallow_schemas.IncidentCountSchema, apply=False)
     @tuning_page
-    def get(self, args, state_id, variable):
+    def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
-        model = cdemodels.OffenseCountView(variable, year=args['year'], state_id=state_id)
+        model = cdemodels.OffenseCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
 

--- a/crime_data/resources/victims.py
+++ b/crime_data/resources/victims.py
@@ -63,9 +63,9 @@ class VictimsCountStates(CdeResource):
             'Victim incidents - By State'))
     @swagger.marshal_with(marshmallow_schemas.IncidentCountSchema, apply=False)
     @tuning_page
-    def get(self, args, state_id, variable):
+    def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
-        model = cdemodels.VictimCountView(variable, year=args['year'], state_id=state_id)
+        model = cdemodels.VictimCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
 
@@ -117,11 +117,12 @@ class VictimOffenseSubcounts(CdeResource):
              'Victim Incidents - By county'))
     @swagger.marshal_with(marshmallow_schemas.CargoTheftCountViewResponseSchema, apply=False)
     @tuning_page
-    def get(self, args, variable, state_id=None):
+    def get(self, args, variable, state_id=None, state_abbr=None):
         self.verify_api_key(args)
         model = cdemodels.OffenseVictimCountView(variable,
                                                  year=args.get('year', None),
                                                  offense_name=args.get('offense_name', None),
-                                                 state_id=state_id)
+                                                 state_id=state_id,
+                                                 state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)

--- a/tests/functional/test_cargo_theft.py
+++ b/tests/functional/test_cargo_theft.py
@@ -18,6 +18,14 @@ class TestCargoTheftEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+    def test_state_endpoint_count_with_postal_code(self, testapp):
+        url = '/ct/count/states/AR/prop_desc_name?year=2014'
+        res = testapp.get(url)
+        assert res.status_code == 200
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
     @pytest.mark.parametrize('variable', CargoTheftCountView.VARIABLES)
     def test_national_endpoint_count(self, testapp, variable):
         url = '/ct/count/national/{}?year=2014'.format(variable)

--- a/tests/functional/test_hate_crime.py
+++ b/tests/functional/test_hate_crime.py
@@ -14,6 +14,14 @@ class TestHateCrimeEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+    def test_state_endpoint_count_with_postal_code(self, testapp):
+        url = '/hc/count/states/AR/bias_name?year=2014'
+        res = testapp.get(url)
+        assert res.status_code == 200
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
     def test_national_endpoint_count(self, testapp):
         url = '/hc/count/national/bias_name?year=2014'
         res = testapp.get(url)

--- a/tests/functional/test_offenders.py
+++ b/tests/functional/test_offenders.py
@@ -17,6 +17,15 @@ class TestOffendersEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+
+    def test_state_endpoint_count_with_postal_code(self, testapp):
+        url = '/offenders/count/states/AR/race_code?year=2014'
+        res = testapp.get(url)
+        assert res.status_code == 200
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
     @pytest.mark.parametrize('variable', OffenderCountView.VARIABLES)
     def test_national_endpoint_count(self, testapp, variable):
         url = '/offenders/count/national/{}?year=2014'.format(variable)

--- a/tests/functional/test_offense_cargo_theft.py
+++ b/tests/functional/test_offense_cargo_theft.py
@@ -26,6 +26,15 @@ class TestVictimsEndpoint:
             assert 'stolen_value' in r
             assert 'recovered_value' in r
 
+    def test_victims_offenses_endpoint_with_postal_code(self, testapp):
+        url = '/ct/count/states/AR/prop_desc_name/offenses?year=2014'
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+            assert 'stolen_value' in r
+            assert 'recovered_value' in r
+
     @pytest.mark.parametrize('variable', OffenseCargoTheftCountView.VARIABLES)
     def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable):
         url = '/ct/count/states/43/{}/offenses?offense_name=Robbery&year=2014'.format(variable)

--- a/tests/functional/test_offense_hate_crime.py
+++ b/tests/functional/test_offense_hate_crime.py
@@ -14,9 +14,23 @@ class TestOffendersOffensesEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+    def test_state_endpoint_no_year_in_request_with_postal_code(self, testapp):
+        res = testapp.get('/hc/count/states/AR/bias_name/offenses')
+        assert 'pagination' in res.json
+        assert res.status_code == 200
+        for r in res.json['results']:
+            assert 'count' in r
+
     @pytest.mark.parametrize('variable', OffenseHateCrimeCountView.VARIABLES)
     def test_victims_offenses_endpoint_with_just_state_year(self, testapp, variable):
         url = '/hc/count/states/43/{}/offenses?year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
+    def test_victims_offenses_endpoint_with_just_state_year_and_postal_code(self, testapp):
+        url = '/hc/count/states/NY/bias_name/offenses?year=2014'
         res = testapp.get(url)
         assert 'pagination' in res.json
         for r in res.json['results']:

--- a/tests/functional/test_offense_victims.py
+++ b/tests/functional/test_offense_victims.py
@@ -22,6 +22,13 @@ class TestVictimsEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+    def test_victims_offenses_endpoint_with_state_postal_code(self, testapp):
+        url = '/victims/count/states/AR/race_code/offenses?year=2014'
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
     @pytest.mark.parametrize('variable', OffenseVictimCountView.VARIABLES)
     def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable):
         url = '/victims/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)

--- a/tests/functional/test_offenses.py
+++ b/tests/functional/test_offenses.py
@@ -37,6 +37,14 @@ class TestOffensesEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+    def test_state_endpoint_count_with_postal_code(self, testapp):
+        url = '/offenses/count/states/AR/weapon_name?year=2014'
+        res = testapp.get(url)
+        assert res.status_code == 200
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
     @pytest.mark.parametrize('variable', OffenseCountView.VARIABLES)
     def test_national_endpoint_count(self, testapp, variable):
         url = '/offenses/count/national/{}?year=2014'.format(variable)

--- a/tests/functional/test_victims.py
+++ b/tests/functional/test_victims.py
@@ -17,6 +17,14 @@ class TestVictimsEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+    def test_state_endpoint_count_with_postal_code(self, testapp):
+        url = '/victims/count/states/AR/race_code?year=2014'
+        res = testapp.get(url)
+        assert res.status_code == 200
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
     @pytest.mark.parametrize('variable', VictimCountView.VARIABLES)
     def test_national_endpoint_count(self, testapp, variable):
         url = '/victims/count/national/{}?year=2014'.format(variable)


### PR DESCRIPTION
To avoid confusion and be consistent with other API endpoints, I changed the various count_view API endpoints to also accept a state_abbr (postal code) instead of a state_id, if you'd prefer. So a query like `victims/count/states/WY` works now