### PR TITLE
Offense mapping

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -222,6 +222,7 @@ def add_resources(app):
     docs.register(crime_data.resources.meta.MetaDetail)
     docs.register(crime_data.resources.geo.StateDetail)
     docs.register(crime_data.resources.geo.CountyDetail)
+    docs.register(crime_data.resources.geo.StateParticipation)
     docs.register(crime_data.resources.offenders.OffendersCountNational)
     docs.register(crime_data.resources.offenders.OffendersCountStates)
     docs.register(crime_data.resources.offenders.OffendersCountCounties)

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -6,7 +6,6 @@ from urllib import parse
 from decimal import Decimal
 from ast import literal_eval
 from functools import wraps
-import more_itertools
 
 import sqltap
 from flask import make_response, request
@@ -511,7 +510,11 @@ class ExplorerOffenseMapping(object):
     NIBRS_OFFENSE_MAPPING = {
         'aggravated-assault': 'Aggravated Assault',
         'burglary': 'Burglary/Breaking & Entering',
-        'larceny': 'Larceny/Theft Offenses', # FIXME: this is a whole category
+        'larceny': ['Not Specified', 'Theft of Motor Vehicle Parts or Accessories',
+                    'Pocket-picking', 'Theft From Motor Vehicle',
+                    'Purse-snatching', 'Shoplifting', 'All Other Larceny',
+                    'Theft From Building',
+                    'Theft From Coin-Operated Machine or Device'],
         'motor-vehicle-theft': 'Motor Vehicle Theft',
         'murder': 'Murder and Nonnegligent Manslaughter',
         'rape': 'Rape',
@@ -519,16 +522,16 @@ class ExplorerOffenseMapping(object):
         'arson': 'Arson'
     }
 
-    def __init__(self, offenses):
-        self.offenses = offenses
+    def __init__(self, offense):
+        self.offense = offense
 
     @property
     def reta_offense(self):
-        return more_itertools.collapse([self.RETA_OFFENSE_MAPPING[x] for x in self.offenses])
+        return self.RETA_OFFENSE_MAPPING[self.offense]
 
     @property
     def nibrs_offense(self):
-        return more_itertools.collapse([self.NIBRS_OFFENSE_MAPPING[x] for x in self.offenses])
+        return self.NIBRS_OFFENSE_MAPPING[self.offense]
 
 
 db = RoutingSQLAlchemy()

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -504,7 +504,8 @@ class ExplorerOffenseMapping(object):
         'motor-vehicle-theft': 'motor vehicle theft',
         'murder': 'murder and nonnegligent homicide',
         'rape': 'rape',
-        'robbery': 'robbery'
+        'robbery': 'robbery',
+        'arson': 'arson'
     }
 
     NIBRS_OFFENSE_MAPPING = {

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -494,6 +494,27 @@ class CdeResource(MethodResource):
             yield (k.lower(), self.OPERATORS[op], v)
 
 
+class ExplorerOffenseMapping(object):
+    """For mapping from explorer offenses to SRS and NIBRS"""
+
+    RETA_OFFENSE_MAPPING = {
+        'aggravated-assault': 'Assault',
+        'burglary': 'Burglary',
+        'larceny': 'Larceny',
+        'motor-vehicle-theft': 'Moter vehicle theft',
+        'murder': 'Murder and Nonnegligent Homicide',
+        'rape': 'Rape',
+        'robbery': 'Robbery',
+    }
+
+    def __init__(self, offense):
+        self.offense = offense
+
+    @property
+    def reta_offense(self):
+        return self.RETA_OFFENSE_MAPPING[self.offense]
+
+
 db = RoutingSQLAlchemy()
 
 

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -6,6 +6,7 @@ from urllib import parse
 from decimal import Decimal
 from ast import literal_eval
 from functools import wraps
+import more_itertools
 
 import sqltap
 from flask import make_response, request
@@ -498,21 +499,36 @@ class ExplorerOffenseMapping(object):
     """For mapping from explorer offenses to SRS and NIBRS"""
 
     RETA_OFFENSE_MAPPING = {
-        'aggravated-assault': 'Assault',
-        'burglary': 'Burglary',
-        'larceny': 'Larceny',
-        'motor-vehicle-theft': 'Moter vehicle theft',
-        'murder': 'Murder and Nonnegligent Homicide',
-        'rape': 'Rape',
-        'robbery': 'Robbery',
+        'aggravated-assault': 'assault',
+        'burglary': 'burglary',
+        'larceny': 'larceny',
+        'motor-vehicle-theft': 'motor vehicle theft',
+        'murder': 'murder and nonnegligent homicide',
+        'rape': 'rape',
+        'robbery': 'robbery'
     }
 
-    def __init__(self, offense):
-        self.offense = offense
+    NIBRS_OFFENSE_MAPPING = {
+        'aggravated-assault': 'Aggravated Assault',
+        'burglary': 'Burglary/Breaking & Entering',
+        'larceny': 'Larceny/Theft Offenses', # FIXME: this is a whole category
+        'motor-vehicle-theft': 'Motor Vehicle Theft',
+        'murder': 'Murder and Nonnegligent Manslaughter',
+        'rape': 'Rape',
+        'robbery': 'Robbery',
+        'arson': 'Arson'
+    }
+
+    def __init__(self, offenses):
+        self.offenses = offenses
 
     @property
     def reta_offense(self):
-        return self.RETA_OFFENSE_MAPPING[self.offense]
+        return more_itertools.collapse([self.RETA_OFFENSE_MAPPING[x] for x in self.offenses])
+
+    @property
+    def nibrs_offense(self):
+        return more_itertools.collapse([self.NIBRS_OFFENSE_MAPPING[x] for x in self.offenses])
 
 
 db = RoutingSQLAlchemy()

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -6,6 +6,7 @@ from flask_marshmallow import Marshmallow
 from marshmallow import fields as marsh_fields
 from marshmallow import Schema, post_dump
 from . import cdemodels, models, newmodels
+from crime_data.common.base import ExplorerOffenseMapping
 
 ma = Marshmallow()
 
@@ -71,7 +72,8 @@ class OffenseCountViewArgs(IncidentViewCountArgs):
     """Adds offense_name as a field"""
 
     offense_name = marsh_fields.String(metadata={'description': 'The NIBRS offense name to subgroup by'})
-
+    explorer_offense = marsh_fields.String(metadata={'description': 'A standardized offense class used by the explorer',
+                                                     'enum': ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys()})
 # Anything in an ArgumentsSchema will, dangerously ironically,
 # not be filtered for...
 

--- a/crime_data/resources/cargo_theft.py
+++ b/crime_data/resources/cargo_theft.py
@@ -27,6 +27,7 @@ class CargoTheftsCountStates(CdeResource):
     @swagger.doc(
         params={'state_id': {'description': 'The state ID from ref_state'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.CargoTheftCountView.VARIABLES}},
         tags=['cargo theft'],
         description=(
@@ -54,6 +55,7 @@ class CargoTheftsCountCounties(CdeResource):
     @swagger.doc(
         params={'county_id': {'description': 'The county ID from ref_county'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.CargoTheftCountView.VARIABLES}},
         tags=['cargo theft'],
         description=(
@@ -75,11 +77,12 @@ class CargoTheftsCountNational(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @swagger.use_kwargs(marshmallow_schemas.IncidentViewCountArgs,
+    @swagger.use_kwargs(marshmallow_schemas.ViewCountArgs,
                         locations=['query'],
                         apply=False)
     @swagger.doc(
         params={'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.CargoTheftCountView.VARIABLES}},
         tags=['cargo theft'],
         description=(
@@ -107,6 +110,7 @@ class CargoTheftOffenseSubcounts(CdeResource):
     @swagger.doc(
         params={'state_id': {'description': 'The ID for a state to limit the query to'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.OffenseCargoTheftCountView.VARIABLES}},
         tags=['cargo theft'],
         description=(

--- a/crime_data/resources/cargo_theft.py
+++ b/crime_data/resources/cargo_theft.py
@@ -119,6 +119,7 @@ class CargoTheftOffenseSubcounts(CdeResource):
         model = cdemodels.OffenseCargoTheftCountView(variable,
                                                      year=args.get('year', None),
                                                      offense_name=args.get('offense_name', None),
+                                                     explorer_offense=args.get('explorer_offense', None),
                                                      state_id=state_id,
                                                      state_abbr=state_abbr)
         results = model.query(args)

--- a/crime_data/resources/hate_crime.py
+++ b/crime_data/resources/hate_crime.py
@@ -28,6 +28,7 @@ class HateCrimesCountStates(CdeResource):
     @swagger.doc(
         params={'state_id': {'description': 'The state ID from ref_state'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.HateCrimeCountView.VARIABLES}},
         tags=['hate crimes'],
         description=(
@@ -40,6 +41,7 @@ class HateCrimesCountStates(CdeResource):
         model = cdemodels.HateCrimeCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
+
 
 class HateCrimesCountCounties(CdeResource):
 
@@ -54,6 +56,7 @@ class HateCrimesCountCounties(CdeResource):
     @swagger.doc(
         params={'county_id': {'description': 'The county ID from ref_county'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.HateCrimeCountView.VARIABLES}},
         tags=['hate crimes'],
         description=(
@@ -67,6 +70,7 @@ class HateCrimesCountCounties(CdeResource):
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
 
+
 class HateCrimesCountNational(CdeResource):
 
     def _stringify(self, data):
@@ -79,6 +83,7 @@ class HateCrimesCountNational(CdeResource):
                         apply=False)
     @swagger.doc(
         params={'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.HateCrimeCountView.VARIABLES}},
         tags=['hate crimes'],
         description='Returns counts by year for hate crimes. ')
@@ -104,6 +109,7 @@ class HateCrimeOffenseSubcounts(CdeResource):
     @swagger.doc(
         params={'state_id': {'description': 'The ID for a state to limit the query to'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.OffenseHateCrimeCountView.VARIABLES}},
         tags=['hate crimes'],
         description=(

--- a/crime_data/resources/hate_crime.py
+++ b/crime_data/resources/hate_crime.py
@@ -117,6 +117,7 @@ class HateCrimeOffenseSubcounts(CdeResource):
         model = cdemodels.OffenseHateCrimeCountView(variable,
                                                     year=args.get('year', None),
                                                     offense_name=args.get('offense_name', None),
+                                                    explorer_offense=args.get('explorer_offense', None),
                                                     state_id=state_id,
                                                     state_abbr=state_abbr)
         results = model.query(args)

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -82,6 +82,12 @@ class CachedIncidentsCount(CdeResource):
     schema = marshmallow_schemas.CachedIncidentCountSchema(many=True)
 
     def postprocess_filters(self, filters, args):
+        # filters, explorer_offenses = partition(lambda x: x[0] == 'explorer_offense', filters)
+        #if explorer_offenses:
+        #    eo = explorer_offenses[0]
+        #    mapper = ExplorerOffenseMapping(eo[2])
+        #    filters.append(('offense', eo[1], mapper.reta_offense))
+
         group_by_column_names = [c.strip() for c in args.get('by').split(',')]
         filters = newmodels.RetaMonthOffenseSubcatSummary.determine_grouping(filters, group_by_column_names, self.schema)
         return filters

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -86,9 +86,9 @@ class CachedIncidentsCount(CdeResource):
 
         if explorer_offenses:
             eo = explorer_offenses[0]
-            mapper = ExplorerOffenseMapping(eo[2])
+            mapped = [ExplorerOffenseMapping(x).reta_offense for x in eo[2]]
             filters = [x for x in filters if x[0] != 'explorer_offense']
-            filters.append(('offense', eo[1], mapper.reta_offense))
+            filters.append(('offense', eo[1], mapped))
 
         group_by_column_names = [c.strip() for c in args.get('by').split(',')]
         filters = newmodels.RetaMonthOffenseSubcatSummary.determine_grouping(filters, group_by_column_names, self.schema)

--- a/crime_data/resources/offenders.py
+++ b/crime_data/resources/offenders.py
@@ -3,7 +3,7 @@ import flask_apispec as swagger
 from webargs.flaskparser import use_args
 
 from crime_data.common import cdemodels, marshmallow_schemas
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, ExplorerOffenseMapping
 
 # Template
 # variables => [location_type, offense_type, property_type, age, sex, race]
@@ -105,6 +105,8 @@ class OffenderOffenseSubcounts(CdeResource):
                         apply=False)
     @swagger.doc(
         params={'state_id': {'description': 'The ID for a state to limit the query to'},
+                'explorer_offense': {'description': 'A offense class used by the explorer',
+                                     'enum': ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys()},
                 'variable': {'description': 'A variable to group by',
                              'enum': cdemodels.OffenseOffenderCountView.VARIABLES}},
         tags=['offenders'],
@@ -118,6 +120,7 @@ class OffenderOffenseSubcounts(CdeResource):
         model = cdemodels.OffenseOffenderCountView(variable,
                                                    year=args.get('year', None),
                                                    offense_name=args.get('offense_name', None),
+                                                   explorer_offense=args.get('explorer_offense', None),
                                                    state_id=state_id)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)

--- a/crime_data/resources/offenders.py
+++ b/crime_data/resources/offenders.py
@@ -108,6 +108,7 @@ class OffenderOffenseSubcounts(CdeResource):
                 'explorer_offense': {'description': 'A offense class used by the explorer',
                                      'enum': ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys()},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.OffenseOffenderCountView.VARIABLES}},
         tags=['offenders'],
         description=(

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -69,6 +69,7 @@ class OffensesCountStates(CdeResource):
         tags=['offenses'],
         params={'state_id': {'description': 'The state ID from ref_county'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.OffenseCountView.VARIABLES}},
         description=(
             'Returns counts by year for offenses. '
@@ -95,6 +96,7 @@ class OffensesCountCounties(CdeResource):
     @swagger.doc(
         params={'county_id': {'description': 'The county ID from ref_county'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.OffenseCountView.VARIABLES}},
         tags=['offenses'],
         description=(

--- a/crime_data/resources/victims.py
+++ b/crime_data/resources/victims.py
@@ -28,6 +28,7 @@ class VictimsCountNational(CdeResource):
     @swagger.doc(
         tags=['victims'],
         params={'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.VictimCountView.VARIABLES}},
         description=(
             'Returns counts by year for victims. '
@@ -57,6 +58,7 @@ class VictimsCountStates(CdeResource):
         tags=['victims'],
         params={'state_id': {'description': 'The state ID from ref_county'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.VictimCountView.VARIABLES}},
         description=(
             'Returns counts by year for victims. '
@@ -83,6 +85,7 @@ class VictimsCountCounties(CdeResource):
     @swagger.doc(
         params={'county_id': {'description': 'The county ID from ref_county'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.VictimCountView.VARIABLES}},
         tags=['victims'],
         description=(
@@ -110,6 +113,7 @@ class VictimOffenseSubcounts(CdeResource):
     @swagger.doc(
         params={'state_id': {'description': 'The ID for a state to limit the query to'},
                 'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
                              'enum': cdemodels.OffenseVictimCountView.VARIABLES}},
         tags=['victims'],
         description=(

--- a/crime_data/resources/victims.py
+++ b/crime_data/resources/victims.py
@@ -122,6 +122,7 @@ class VictimOffenseSubcounts(CdeResource):
         model = cdemodels.OffenseVictimCountView(variable,
                                                  year=args.get('year', None),
                                                  offense_name=args.get('offense_name', None),
+                                                 explorer_offense=args.get('explorer_offense', None),
                                                  state_id=state_id,
                                                  state_abbr=state_abbr)
         results = model.query(args)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 # Everything needed in production
-
+more_itertools==2.5.0
 wheel==0.29.0
 
 # Flask

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,4 @@
 # Everything needed in production
-more_itertools==2.5.0
 wheel==0.29.0
 
 # Flask

--- a/tests/functional/test_incidents.py
+++ b/tests/functional/test_incidents.py
@@ -322,6 +322,11 @@ class TestIncidentsCountEndpoint:
         rows = [row['offense'] for row in res.json['results']]
         assert len(rows) == len(set(rows))
 
+    def test_instances_count_filter_by_explorer_offense(self, testapp):
+        res = testapp.get('/incidents/count/?explorer_offense=larceny')
+        rows = [row['offense'] for row in res.json['results']]
+        assert len(rows) == len(set(rows))
+
     def test_instances_count_sorts_by_state(self, testapp):
         res = testapp.get('/incidents/count/?by=state')
         state_names = [r['state'] for r in res.json['results']]

--- a/tests/functional/test_offense_cargo_theft.py
+++ b/tests/functional/test_offense_cargo_theft.py
@@ -5,6 +5,7 @@ See: http://webtest.readthedocs.org/
 """
 import pytest
 from crime_data.common.cdemodels import OffenseCargoTheftCountView
+from crime_data.common.base import ExplorerOffenseMapping
 
 class TestVictimsEndpoint:
     def test_state_endpoint_no_year_in_request(self, testapp):
@@ -37,7 +38,18 @@ class TestVictimsEndpoint:
 
     @pytest.mark.parametrize('variable', OffenseCargoTheftCountView.VARIABLES)
     def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable):
-        url = '/ct/count/states/43/{}/offenses?offense_name=Robbery&year=2014'.format(variable)
+        url = '/ct/count/states/48/{}/offenses?offense_name=Robbery&year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+            assert 'stolen_value' in r
+            assert 'recovered_value' in r
+
+    @pytest.mark.parametrize('variable', OffenseCargoTheftCountView.VARIABLES)
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    def test_victims_offenses_endpoint_with_state_year_explorer_offense(self, testapp, variable, explorer_offense):
+        url = '/ct/count/states/48/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
         res = testapp.get(url)
         assert 'pagination' in res.json
         for r in res.json['results']:

--- a/tests/functional/test_offense_hate_crime.py
+++ b/tests/functional/test_offense_hate_crime.py
@@ -5,6 +5,7 @@ See: http://webtest.readthedocs.org/
 """
 import pytest
 from crime_data.common.cdemodels import OffenseHateCrimeCountView
+from crime_data.common.base import ExplorerOffenseMapping
 
 class TestOffendersOffensesEndpoint:
     def test_state_endpoint_no_year_in_request(self, testapp):
@@ -39,6 +40,15 @@ class TestOffendersOffensesEndpoint:
     @pytest.mark.parametrize('variable', OffenseHateCrimeCountView.VARIABLES)
     def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable):
         url = '/hc/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
+    @pytest.mark.parametrize('variable', OffenseHateCrimeCountView.VARIABLES)
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable, explorer_offense):
+        url = '/hc/count/states/43/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
         res = testapp.get(url)
         assert 'pagination' in res.json
         for r in res.json['results']:

--- a/tests/functional/test_offense_offenders.py
+++ b/tests/functional/test_offense_offenders.py
@@ -5,6 +5,7 @@ See: http://webtest.readthedocs.org/
 """
 import pytest
 from crime_data.common.cdemodels import OffenseOffenderCountView
+from crime_data.common.base import ExplorerOffenseMapping
 
 class TestOffendersOffensesEndpoint:
     def test_state_endpoint_no_year_in_request(self, testapp):
@@ -25,6 +26,15 @@ class TestOffendersOffensesEndpoint:
     @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
     def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable):
         url = '/offenders/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
+    @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    def test_victims_offenses_endpoint_with_state_year_explorer_offense(self, testapp, variable, explorer_offense):
+        url = '/offenders/count/states/43/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
         res = testapp.get(url)
         assert 'pagination' in res.json
         for r in res.json['results']:

--- a/tests/functional/test_offense_victims.py
+++ b/tests/functional/test_offense_victims.py
@@ -5,6 +5,7 @@ See: http://webtest.readthedocs.org/
 """
 import pytest
 from crime_data.common.cdemodels import OffenseVictimCountView
+from crime_data.common.base import ExplorerOffenseMapping
 
 class TestVictimsEndpoint:
     def test_state_endpoint_no_year_in_request(self, testapp):
@@ -32,6 +33,15 @@ class TestVictimsEndpoint:
     @pytest.mark.parametrize('variable', OffenseVictimCountView.VARIABLES)
     def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable):
         url = '/victims/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
+    @pytest.mark.parametrize('variable', OffenseVictimCountView.VARIABLES)
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable, explorer_offense):
+        url = '/victims/count/states/43/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
         res = testapp.get(url)
         assert 'pagination' in res.json
         for r in res.json['results']:

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from crime_data.common.base import ExplorerOffenseMapping
 from crime_data.common.cdemodels import (CdeRefState,
                                          CdeRefCounty,
                                          CdeRefAgencyCounty,
@@ -384,6 +385,28 @@ class TestOffenseVictimCountView:
             assert row_key not in seen_values
             seen_values.add(row_key)
 
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    @pytest.mark.parametrize('variable', ['race_code'])
+    def test_endpoint_for_explorer_offense(self, app, explorer_offense, variable):
+        v = OffenseVictimCountView(variable, year=1992, state_id=2, explorer_offense=explorer_offense)
+        results = v.query({}).fetchall()
+        if len(results) > 0:
+            seen_values = set()
+            for row in results:
+                row_key = (row.year, row.offense_name, row[variable], )
+                assert row_key not in seen_values
+                seen_values.add(row_key)
+
+    def test_explorer_offense_does_aggregation(self, app):
+        v = OffenseVictimCountView('sex_code', year=2014, state_id=26, explorer_offense='larceny')
+        results = v.query({}).fetchall()
+        expected = [
+            ('2014', 'larceny', 'F', 3),
+            ('2014', 'larceny', 'M', 3)]
+        assert len(results) == len(expected)
+        for row, expect in zip(results, expected):
+            assert row == expect
+
 
 class TestOffenseOffenderCountView:
     """Test the OffenseOffenderCountView"""
@@ -412,6 +435,28 @@ class TestOffenseOffenderCountView:
             row_key = (row.year, row.offense_name, row[variable], )
             assert row_key not in seen_values
             seen_values.add(row_key)
+
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
+    def test_endpoint_for_explorer_offense(self, app, explorer_offense, variable):
+        v = OffenseOffenderCountView(variable, year=1992, state_id=2, explorer_offense=explorer_offense)
+        results = v.query({}).fetchall()
+        if len(results) > 0:
+            seen_values = set()
+            for row in results:
+                row_key = (row.year, row.offense_name, row[variable], )
+                assert row_key not in seen_values
+                seen_values.add(row_key)
+
+    def test_explorer_offense_does_aggregation(self, app):
+        v = OffenseOffenderCountView('sex_code', year=2014, state_id=26, explorer_offense='larceny')
+        results = v.query({}).fetchall()
+        expected = [
+            ('2014', 'larceny', 'F', 1),
+            ('2014', 'larceny', 'M', 2)]
+        assert len(results) == len(expected)
+        for row, expect in zip(results, expected):
+            assert row == expect
 
 
 class TestOffenseCargoTheftCountView:
@@ -443,6 +488,37 @@ class TestOffenseCargoTheftCountView:
             assert row_key not in seen_values
             seen_values.add(row_key)
 
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    @pytest.mark.parametrize('variable', OffenseCargoTheftCountView.VARIABLES)
+    def test_endpoint_for_explorer_offense(self, app, explorer_offense, variable):
+        v = OffenseCargoTheftCountView(variable, year=1992, state_id=2, explorer_offense=explorer_offense)
+        results = v.query({}).fetchall()
+        if len(results) > 0:
+            seen_values = set()
+            for row in results:
+                row_key = (row.year, row.offense_name, row[variable], )
+                assert row_key not in seen_values
+                seen_values.add(row_key)
+
+    def test_explorer_offense_does_aggregation(self, app):
+        v = OffenseCargoTheftCountView('prop_desc_name', year=2014, state_id=26, explorer_offense='larceny')
+        results = v.query({}).fetchall()
+        expected = [
+            ('2014', 'larceny', 'Bicycles', 1, '85', '0'),
+            ('2014', 'larceny', 'Computer Hard/ Software', 3, '2800', '0'),
+            ('2014', 'larceny', 'Consumable Goods', 2, '71', '0'),
+            ('2014', 'larceny', 'Jewelry/ Precious Metals', 1, '12678', '7039'),
+            ('2014', 'larceny', 'Merchandise', 2, '92', '0'),
+            ('2014', 'larceny', 'Money', 4, '545', '5'),
+            ('2014', 'larceny', 'Other', 1, '4401', '4000'),
+            ('2014', 'larceny', 'Photographic/ Optical Equipment', 1, '400', '0'),
+            ('2014', 'larceny', 'Portable Electronic Communications', 3, '502', '0'),
+            ('2014', 'larceny', 'Tools', 1, '420', '0'),
+            ('2014', 'larceny', 'Vehicle Parts', 1, '300', '0')]
+        assert len(results) == len(expected)
+        for row, expect in zip(results, expected):
+            assert row == expect
+
 
 class TestOffenseHateCrimeCountView:
     """Test the OffenseOffenderCountView"""
@@ -472,3 +548,15 @@ class TestOffenseHateCrimeCountView:
             row_key = (row.year, row.offense_name, row[variable], )
             assert row_key not in seen_values
             seen_values.add(row_key)
+
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    @pytest.mark.parametrize('variable', OffenseHateCrimeCountView.VARIABLES)
+    def test_endpoint_for_explorer_offense(self, app, explorer_offense, variable):
+        v = OffenseHateCrimeCountView(variable, year=1992, state_id=2, explorer_offense=explorer_offense)
+        results = v.query({}).fetchall()
+        if len(results) > 0:
+            seen_values = set()
+            for row in results:
+                row_key = (row.year, row.offense_name, row[variable], )
+                assert row_key not in seen_values
+                seen_values.add(row_key)


### PR DESCRIPTION
The idea of this is that the frontend API should only have to pass a single universal argument for offenses and it is mapped to the appropriate RET A or NIBRS offenses in the backend. So, this call `/incidents/count/?explorer_offense=murder` is actually mapped to use the RET A offense code we are displaying for murder. Similarly, it can be used with the NIBRS endpoints as well, but I still have to wire that up.