### PR TITLE
Police employee count should only be for reporting agencies

### DIFF
--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -166,6 +166,7 @@ class CdeRefState(models.RefState):
             .filter(CdeRefAgency.state_id == self.state_id)
             .filter(CdeRefAgency.agency_id == models.PeEmployeeData.agency_id)
             .filter(models.PeEmployeeData.data_year == data_year)
+            .filter(models.PeEmployeeData.reported_flag == 'Y')
         )
 
         return query.scalar()
@@ -290,6 +291,7 @@ class CdeRefCounty(models.RefCounty):
             .filter(CdeRefAgencyCounty.county_id == self.county_id)
             .filter(CdeRefAgency.agency_id == models.PeEmployeeData.agency_id)
             .filter(models.PeEmployeeData.data_year == data_year)
+            .filter(models.PeEmployeeData.reported_flag == 'Y')
         )
 
         print(query)


### PR DESCRIPTION
Fixes #368 

Guidance from the FBI is that we should only use pe_employee_data fields where reported_flag='Y' to compute police staffing