### PR TITLE
Disabling caching for the CdeRefState

### DIFF
--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -175,22 +175,9 @@ class CdeRefState(models.RefState):
         """Returns the total police officers for the current year"""
         return self.police_officers_for_year(self.current_year)
 
-    @property
-    def participation_cache(self):
-        try:
-            return self._participation_cache
-        except AttributeError:
-            self._participation_cache = {}
-            return self._participation_cache
-
     def _participation_for_year(self, year):
-        """Internal method for loading the participation data"""
-        try:
-            return self.participation_cache[year]
-        except KeyError:
-            l = CdeParticipationRate(state_id=self.state_id, year=year).query.one()
-            self.participation_cache[year] = l
-            return l
+        l = CdeParticipationRate(state_id=self.state_id, year=year).query.one()
+        return l
 
 
 class CdeRefCounty(models.RefCounty):
@@ -300,24 +287,12 @@ class CdeRefCounty(models.RefCounty):
         """Returns the total police officers for the current year"""
         return self.police_officers_for_year(self.current_year)
 
-    @property
-    def participation_cache(self):
-        try:
-            return self._participation_cache
-        except AttributeError:
-            self._participation_cache = {}
-            return self._participation_cache
-
     def _participation_for_year(self, year):
         """Internal method for loading the participation data"""
-        try:
-            return self.participation_cache[year]
-        except KeyError:
-            l = CdeParticipationRate(county_id=self.county_id, year=year).query.one()
-            self.participation_cache[year] = l
-            return l
+        l = CdeParticipationRate(county_id=self.county_id, year=year).query.one()
+        return l
 
-    
+
 class CdeRefAgency(models.RefAgency):
     def get(ori=None):
         # Base Query

--- a/crime_data/resources/geo.py
+++ b/crime_data/resources/geo.py
@@ -16,6 +16,7 @@ class StateDetail(CdeResource):
     @swagger.doc(tags=['geo'],
                  params={'state_id': {'description': 'A state postal abbreviation'}},
                  description=['Returns basic information about a state and lists counties in the state'])
+    @tuning_page
     def get(self, args, id):
         self.verify_api_key(args)
         state = cdemodels.CdeRefState.get(abbr=id).one()
@@ -29,6 +30,7 @@ class CountyDetail(CdeResource):
     @swagger.use_kwargs(marshmallow_schemas.ApiKeySchema, apply=False, locations=['query'])
     @swagger.marshal_with(marshmallow_schemas.CountyDetailResponseSchema, apply=False)
     @swagger.doc(tags=['geo'], description='Demographic details for a county')
+    @tuning_page
     def get(self, args, fips):
         self.verify_api_key(args)
         county = cdemodels.CdeRefCounty.get(fips=fips).one()
@@ -42,6 +44,7 @@ class StateParticipation(CdeResource):
     @swagger.use_kwargs(marshmallow_schemas.ApiKeySchema, apply=False, locations=['query'])
     @swagger.marshal_with(marshmallow_schemas.ParticipationRateSchema, apply=False)
     @swagger.doc(tags=['geo'], description='Participation data for a state')
+    @tuning_page
     def get(self, args, state_id=None, state_abbr=None):
         self.verify_api_key(args)
 

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -124,6 +124,16 @@ class TestCdeRefState:
         #                         AND rm.data_year=1960 and ra.state_id=55)
         assert state.covered_population_for_year(test_year) == 177770
 
+    def test_participation_cache_is_not_global(self, app):
+        test_year = 1960
+        state1 = CdeRefState.get(abbr='NY').one()
+        state2 = CdeRefState.get(abbr='DE').one()
+        assert state1 != state2
+        assert state1.state_id != state2.state_id
+        p1 = state1.total_population_for_year(test_year)
+        p2 = state2.total_population_for_year(test_year)
+        assert p1 != p2
+
 
 class TestOffenseCountView:
     """Test the OffenseCountView"""


### PR DESCRIPTION
Fixes #366

For some reason, it's sharing the cached object across all instances. Python, I don't understand you sometimes.