### PR TITLE
Add participation data to the /geo/states/ endpoint

### DIFF
--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -180,6 +180,10 @@ class CdeRefState(models.RefState):
         l = CdeParticipationRate(state_id=self.state_id, year=year).query.one()
         return l
 
+    @property
+    def participation_rates(self):
+        return CdeParticipationRate(state_id=self.state_id).query.order_by('data_year DESC').all()
+
 
 class CdeRefCounty(models.RefCounty):
     """A wrapper around the RefCounty model with extra methods."""

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -901,6 +901,23 @@ class CodeIndexResponseSchema(Schema):
     key = marsh_fields.String()
 
 
+class ParticipationRateSchema(ma.ModelSchema):
+    """Response format for participation record"""
+
+    class Meta:
+        # model = cdemodels.CdeParticipationRate
+        ordered = True
+        fields = ('year', 'total_population', 'covered_population',
+                  'total_agencies', 'reporting_agencies', 'reporting_rate')
+
+    year = marsh_fields.Integer(attribute='data_year')
+    total_population = marsh_fields.Integer()
+    covered_population = marsh_fields.Integer()
+    total_agencies = marsh_fields.Integer()
+    reporting_agencies = marsh_fields.Integer()
+    reporting_rate = marsh_fields.Float()
+
+
 class StateCountyResponseSchema(ma.ModelSchema):
     """Schema for counties in the StateDetail response."""
 
@@ -920,7 +937,8 @@ class StateDetailResponseSchema(ma.ModelSchema):
         ordered = True
         fields = ('state_id', 'name', 'postal_abbr', 'fips_code', 'current_year',
                   'reporting_agencies', 'covered_population', 'reporting_rate',
-                  'total_population', 'total_agencies', 'police_officers', 'counties', )
+                  'total_population', 'total_agencies', 'police_officers', 'counties',
+                  'participation', )
 
     name = marsh_fields.String(attribute='state_name')
     postal_abbr = marsh_fields.String(attribute='state_postal_abbr')
@@ -937,6 +955,9 @@ class StateDetailResponseSchema(ma.ModelSchema):
     counties = ma.Nested(StateCountyResponseSchema,
                          attribute='counties',
                          many=True)
+    participation = ma.Nested(ParticipationRateSchema,
+                              attribute='participation_rates',
+                              many=True)
 
 
 class CountyDetailResponseSchema(ma.ModelSchema):
@@ -957,19 +978,3 @@ class CountyDetailResponseSchema(ma.ModelSchema):
     state_name = marsh_fields.String()
     state_abbr = marsh_fields.String()
 
-
-class ParticipationRateSchema(ma.ModelSchema):
-    """Response format for participation record"""
-
-    class Meta:
-        # model = cdemodels.CdeParticipationRate
-        ordered = True
-        fields = ('year', 'total_population', 'covered_population',
-                  'total_agencies', 'reporting_agencies', 'reporting_rate')
-
-    year = marsh_fields.Integer(attribute='data_year')
-    total_population = marsh_fields.Integer()
-    covered_population = marsh_fields.Integer()
-    total_agencies = marsh_fields.Integer()
-    reporting_agencies = marsh_fields.Integer()
-    reporting_rate = marsh_fields.Float()


### PR DESCRIPTION
See https://github.com/18F/crime-data-explorer/issues/125 for details.

This adds a `participation` key to the object returned by the `/geo/states/<state_id>` endpoint. We can probably remove the separate `/geo/states/<state_id>/participation` endpoint once this is merged.