### PR TITLE
Add NIBRS-specific counts to participation tables

### DIFF
--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -804,7 +804,8 @@ class AgencyParticipationSchema(Schema):
         model = newmodels.AgencyAnnualParticipation
         fields = ('year', 'state_name', 'state_abbr', 'agency_id', 'agency_ori',
                   'agency_name', 'agency_population', 'population_group_code',
-                  'population_group', 'reported', 'reported_12mos')
+                  'population_group', 'reported', 'months_reported',
+                  'reported_nibrs', 'months_reported_nibrs', )
         exclude = ('agency_id', )
         ordered = True
 
@@ -929,6 +930,26 @@ class StateCountyResponseSchema(ma.ModelSchema):
     population = marsh_fields.Integer()
 
 
+class ParticipationRateSchema(ma.ModelSchema):
+    """Response format for participation record"""
+
+    class Meta:
+        # model = cdemodels.CdeParticipationRate
+        ordered = True
+        fields = ('year', 'total_population', 'covered_population',
+                  'total_agencies', 'reporting_agencies', 'reporting_rate',
+                  'nibrs_reporting_agencies', 'nibrs_reporting_rate',)
+
+    year = marsh_fields.Integer(attribute='data_year')
+    total_population = marsh_fields.Integer()
+    covered_population = marsh_fields.Integer()
+    total_agencies = marsh_fields.Integer()
+    reporting_agencies = marsh_fields.Integer()
+    reporting_rate = marsh_fields.Float()
+    nibrs_reporting_agencies = marsh_fields.Integer()
+    nibrs_reporting_rate = marsh_fields.Float()
+
+
 class StateDetailResponseSchema(ma.ModelSchema):
     """Response schema for the StateDetail API method."""
 
@@ -977,4 +998,5 @@ class CountyDetailResponseSchema(ma.ModelSchema):
     police_officers = marsh_fields.Integer()
     state_name = marsh_fields.String()
     state_abbr = marsh_fields.String()
+
 

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -35,7 +35,9 @@ class AgencyAnnualParticipation(db.Model):
     population_group_code = db.Column(db.String)
     population_group = db.Column(db.String)
     reported = db.Column(db.SmallInteger, nullable=False)
-    reported_12mos = db.Column(db.SmallInteger, nullable=False)
+    months_reported = db.Column(db.SmallInteger, nullable=False)
+    reported_nibrs = db.Column(db.SmallInteger, nullable=False)
+    months_reported_nibrs = db.Column(db.SmallInteger, nullable=False)
 
     @classmethod
     def column_is_string(cls, col_name):
@@ -73,6 +75,8 @@ class ParticipationRate(db.Model):
     total_agencies = db.Column(db.Integer)
     reporting_agencies = db.Column(db.Integer)
     reporting_rate = db.Column(db.Float)
+    nibrs_reporting_agencies = db.Column(db.Integer)
+    nibrs_reporting_rate = db.Column(db.Float)
     state_id = db.Column(db.Integer)
     county_id = db.Column(db.Integer)
 

--- a/tests/unit/test_newmodels.py
+++ b/tests/unit/test_newmodels.py
@@ -1,7 +1,45 @@
 # -*- coding: utf-8 -*-
 
-from crime_data.common.newmodels import RetaMonthOffenseSubcatSummary
+from crime_data.common.newmodels import (RetaMonthOffenseSubcatSummary,
+                                         AgencyAnnualParticipation,
+                                         ParticipationRate)
 import pytest
+
+class TestAgencyAnnualParticipation:
+    # Agency 191, 1991
+    def test_for_agency_in_nibrs_month(self, app):
+        q = AgencyAnnualParticipation.query
+        q = q.filter(AgencyAnnualParticipation.data_year == 1991)
+        q = q.filter(AgencyAnnualParticipation.agency_id == 191).one()
+        assert q.reported == 1
+        assert q.months_reported == 2
+        assert q.reported_nibrs == 1
+        assert q.morths_reported_nibrs == 2
+
+    def test_for_agency_not_in_nibrs_month(self, app):
+        q = AgencyAnnualParticipation.query
+        q = q.filter(AgencyAnnualParticipation.data_year == 2002)
+        q = q.filter(AgencyAnnualParticipation.agency_id == 9744).one()
+        assert q.reported == 1
+        assert q.months_reported == 3
+        assert q.reported_nibrs == 0
+        assert q.months_reported_nibrs == 0
+
+
+class TestParticipationRate:
+    def test_for_state_in_year(self, app):
+        q = ParticipationRate.query
+        q = q.filter(ParticipationRate.data_year == 1991)
+        q = q.filter(ParticipationRate.state_id == 2).one()
+        assert q.data_year == 1991
+        assert q.state_id == 2
+        assert q.total_agencies == 1
+        assert q.reporting_agencies == 1
+        assert q.reporting_rate == 1
+        assert q.nibrs_reporting_agencies == 1
+        assert q.nibrs_reporting_rate == 1
+        assert q.total_population == None
+        assert q.covered_population == 0
 
 
 class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:

--- a/tests/unit/test_newmodels.py
+++ b/tests/unit/test_newmodels.py
@@ -6,7 +6,6 @@ from crime_data.common.newmodels import (RetaMonthOffenseSubcatSummary,
 import pytest
 
 class TestAgencyAnnualParticipation:
-    # Agency 191, 1991
     def test_for_agency_in_nibrs_month(self, app):
         q = AgencyAnnualParticipation.query
         q = q.filter(AgencyAnnualParticipation.data_year == 1991)
@@ -14,7 +13,7 @@ class TestAgencyAnnualParticipation:
         assert q.reported == 1
         assert q.months_reported == 2
         assert q.reported_nibrs == 1
-        assert q.morths_reported_nibrs == 2
+        assert q.months_reported_nibrs == 2
 
     def test_for_agency_not_in_nibrs_month(self, app):
         q = AgencyAnnualParticipation.query


### PR DESCRIPTION
Fixes #384 

The nibrs_month table tells us if an agency has filed a NIBRS report in a given month (reta_month covers both agencies that filed RET A reports, those that filed both and those that filed only NIBRS reports that were then converted over). Since we display some statistics from NIBRS data, it might be good to show those specific rates