### PR TITLE
A few csv fixes

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -212,7 +212,7 @@ class CdeResource(MethodResource):
         """This could potentially look at args for ordering directives in the future."""
         return qry
 
-    def _get(self, args):
+    def _get(self, args, csv_filename='incidents'):
         # TODO: apply "fields" arg
 
         self.verify_api_key(args)
@@ -237,7 +237,7 @@ class CdeResource(MethodResource):
                 self.with_metadata(qry,
                                    args), self.schema, 'csv', aggregate_many))
             output.headers[
-                "Content-Disposition"] = "attachment; filename=incidents.csv"
+                "Content-Disposition"] = "attachment; filename={}.csv".format(csv_filename)
             output.headers["Content-type"] = "text/csv"
             return output
         return self.with_metadata(qry, args)

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -226,21 +226,27 @@ class CdeResource(MethodResource):
             qry = self.tables.group_by(qry, group_columns)
         else:
             qry = self.set_ordering(qry, args)
+        return self.render_response(qry, args, csv_filename=csv_filename)
 
-        aggregate_many = False
-
-        if args['aggregate_many'] == 'true':
-            aggregate_many = True
-
+    def render_response(self, qry, args, csv_filename='incidents'):
         if args['output'] == 'csv':
-            output = make_response(self.output_serialize(
-                self.with_metadata(qry,
-                                   args), self.schema, 'csv', aggregate_many))
+            aggregate_many = False
+
+            if args['aggregate_many'] == 'true':
+                aggregate_many = True
+
+            output = make_response(
+                self.output_serialize(
+                    self.with_metadata(qry, args),
+                    self.schema,
+                    'csv',
+                    aggregate_many))
             output.headers[
-                "Content-Disposition"] = "attachment; filename={}.csv".format(csv_filename)
-            output.headers["Content-type"] = "text/csv"
+                'Content-Disposition'] = 'attachment; filename={}.csv'.format(csv_filename)
+            output.headers['Content-type'] = 'text/csv'
             return output
-        return self.with_metadata(qry, args)
+        else:
+            return self.with_metadata(qry, args)
 
     def _serialize_dict(self,
                         data,

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -46,6 +46,26 @@ class AgenciesParticipation(CdeResource):
     tables = newmodels.AgencyAnnualParticipation
     is_groupable = False
 
+    def postprocess_filters(self, filters, args):
+        years = [x for x in filters if x[0] == 'year']
+
+        print(filters)
+        if years:
+            y = years[0]
+            data_year = y[2][0]
+            match = re.search('(\d{4})-(\d{4})', str(data_year))
+            if match:
+                data_years = list(range(int(match.group(1)), int(match.group(2))))
+            else:
+                data_years = [data_years]
+
+            print(data_year)
+            filters = [x for x in filters if x[0] != 'year']
+            filters.append(('data_year', y[1], data_years))
+
+        return filters
+
+
     @use_args(marshmallow_schemas.ArgumentsSchema)
     @swagger.use_kwargs(marshmallow_schemas.ArgumentsSchema, apply=False, locations=['query'])
     @swagger.doc(tags=['agencies', 'participation'],

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -53,4 +53,4 @@ class AgenciesParticipation(CdeResource):
     @swagger.marshal_with(marshmallow_schemas.AgenciesParticipationResponseSchema, apply=False)
     @tuning_page
     def get(self, args):
-        return self._get(args)
+        return self._get(args, csv_filename='agency_participation')

--- a/crime_data/resources/geo.py
+++ b/crime_data/resources/geo.py
@@ -48,8 +48,7 @@ class StateParticipation(CdeResource):
     def get(self, args, state_id=None, state_abbr=None):
         self.verify_api_key(args)
 
-        if state_abbr:
-            state_id = cdemodels.CdeRefState.get(abbr=state_abbr).one().state_id
-
-        rates = cdemodels.CdeParticipationRate(state_id=state_id).query.order_by('data_year DESC').all()
-        return jsonify(self.schema.dump(rates).data)
+        state = cdemodels.CdeRefState.get(abbr=state_abbr, state_id=state_id).one()
+        rates = cdemodels.CdeParticipationRate(state_id=state.state_id).query.order_by('data_year DESC').all()
+        filename = '{}_state_participation'.format(state.state_postal_abbr)
+        return self.render_response(rates, args, csv_filename=filename)


### PR DESCRIPTION
Fixes https://github.com/18F/crime-data-explorer/issues/312

This does a few things:
1. Add support to pass an `output=csv` argument to the `geo/states/<state_id>/participation` endpoint
2. The `/agencies/participation` endpoint also accepts a `year=1991` or ranged `year=1991-2001` arguments