### PR TITLE
Explorer offense should be argument to offense count view

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -202,6 +202,10 @@ def add_resources(app):
                      '/offenders/count/states/<int:state_id>/<string:variable>/offenses',
                      '/offenders/count/states/<string:state_abbr>/<string:variable>/offenses',
                      '/offenders/count/national/<string:variable>/offenses')
+    api.add_resource(crime_data.resources.offenses.OffenseByOffenseTypeSubcounts,
+                     '/offenses/count/states/<int:state_id>/<string:variable>/offenses',
+                     '/offenses/count/states/<string:state_abbr>/<string:variable>/offenses',
+                     '/offenses/count/national/<string:variable>/offenses')
     api.add_resource(crime_data.resources.hate_crime.HateCrimeOffenseSubcounts,
                      '/hc/count/states/<int:state_id>/<string:variable>/offenses',
                      '/hc/count/states/<string:state_abbr>/<string:variable>/offenses',
@@ -238,6 +242,7 @@ def add_resources(app):
     docs.register(crime_data.resources.hate_crime.HateCrimesCountNational)
     docs.register(crime_data.resources.hate_crime.HateCrimesCountStates)
     docs.register(crime_data.resources.hate_crime.HateCrimesCountCounties)
+    docs.register(crime_data.resources.offenses.OffenseByOffenseTypeSubcounts)
     docs.register(crime_data.resources.victims.VictimOffenseSubcounts)
     docs.register(crime_data.resources.offenders.OffenderOffenseSubcounts)
     docs.register(crime_data.resources.cargo_theft.CargoTheftOffenseSubcounts)

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -1362,6 +1362,12 @@ class OffenseOffenderCountView(OffenseSubCountView):
     def view_name(self):
         return 'offense_offender_counts'
 
+class OffenseByOffenseTypeCountView(OffenseSubCountView):
+    VARIABLES = ['weapon_name', 'method_entry_code', 'num_premises_entered', 'location_name']
+
+    @property
+    def view_name(self):
+        return 'offense_offense_counts'
 
 class OffenseCargoTheftCountView(OffenseSubCountView):
 

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -109,3 +109,36 @@ class OffensesCountCounties(CdeResource):
         model = cdemodels.OffenseCountView(variable, year=args['year'], county_id=county_id)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)
+
+
+class OffenseByOffenseTypeSubcounts(CdeResource):
+
+    def _stringify(self, data):
+        # Override stringify function to fit our needs.
+        return [dict(r) for r in data]
+
+    @use_args(marshmallow_schemas.OffenseCountViewArgs)
+    @swagger.use_kwargs(marshmallow_schemas.OffenseCountViewArgs,
+                        locations=['query'],
+                        apply=False)
+    @swagger.doc(
+        params={'state_id': {'description': 'The ID for a state to limit the query to'},
+                'variable': {'description': 'A variable to group by',
+                             'locations': ['path'],
+                             'enum': cdemodels.OffenseByOffenseTypeCountView.VARIABLES}},
+        tags=['victims'],
+        description=(
+             'Returns counts by year for victims. '
+             'Victim Incidents - By county'))
+    @swagger.marshal_with(marshmallow_schemas.OffenseCountViewResponseSchema, apply=False)
+    @tuning_page
+    def get(self, args, variable, state_id=None, state_abbr=None):
+        self.verify_api_key(args)
+        model = cdemodels.OffenseByOffenseTypeCountView(variable,
+                                                        year=args.get('year', None),
+                                                        offense_name=args.get('offense_name', None),
+                                                        explorer_offense=args.get('explorer_offense', None),
+                                                        state_id=state_id,
+                                                        state_abbr=state_abbr)
+        results = model.query(args)
+        return self.with_metadata(results.fetchall(), args)

--- a/dba/after_load/mat-views/aggregate-views.sql
+++ b/dba/after_load/mat-views/aggregate-views.sql
@@ -157,5 +157,5 @@ create materialized view offense_offense_counts as
     SELECT *,1995 as year  FROM offense_offense_counts_1995 UNION
     SELECT *,1994 as year  FROM offense_offense_counts_1994 UNION 
     SELECT *,1993 as year  FROM offense_offense_counts_1993 UNION 
-    SELECT *,1993 as year  FROM offense_offense_counts_1992 UNION
-    SELECT *,1992 as year  FROM offense_offense_counts_1991;
+    SELECT *,1992 as year  FROM offense_offense_counts_1992 UNION
+    SELECT *,1991 as year  FROM offense_offense_counts_1991;

--- a/tests/functional/test_offense_by_offense_types.py
+++ b/tests/functional/test_offense_by_offense_types.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Functional tests using WebTest.
+
+See: http://webtest.readthedocs.org/
+"""
+import pytest
+from crime_data.common.cdemodels import OffenseByOffenseTypeCountView
+from crime_data.common.base import ExplorerOffenseMapping
+
+class TestOffenseByOffenseTypesEndpoint:
+    def test_state_endpoint_no_year_in_request(self, testapp):
+        res = testapp.get('/offenses/count/states/3/location_name/offenses')
+        assert 'pagination' in res.json
+        assert res.status_code == 200
+        for r in res.json['results']:
+            assert 'count' in r
+
+    @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
+    def test_offenses_endpoint_with_just_state_year(self, testapp, variable):
+        url = '/offenses/count/states/43/{}/offenses?year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
+    @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
+    def test_offenses_endpoint_with_state_year_offense(self, testapp, variable):
+        url = '/offenses/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
+    @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    def test_offenses_endpoint_with_state_year_explorer_offense(self, testapp, variable, explorer_offense):
+        url = '/offenses/count/states/43/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -9,6 +9,7 @@ from crime_data.common.cdemodels import (CdeRefState,
                                          VictimCountView,
                                          CargoTheftCountView,
                                          HateCrimeCountView,
+                                         OffenseByOffenseTypeCountView,
                                          OffenseVictimCountView,
                                          OffenseOffenderCountView,
                                          OffenseCargoTheftCountView,
@@ -464,6 +465,60 @@ class TestOffenseOffenderCountView:
         expected = [
             ('2014', 'larceny', 'F', 1),
             ('2014', 'larceny', 'M', 2)]
+        assert len(results) == len(expected)
+        for row, expect in zip(results, expected):
+            assert row == expect
+
+
+class TestOffenseByOffenseTypeCountView:
+    """Test the OffenseByOffenseTypeCountView"""
+
+    def test_count_for_a_state(self, app):
+        v = OffenseByOffenseTypeCountView('weapon_name', year=1999, state_id=47, offense_name='Aggravated Assault')
+        results = v.query({}).fetchall()
+
+        expected = [
+            ('1999', 'Aggravated Assault', 'Blunt Object', 1),
+            ('1999', 'Aggravated Assault', 'Motor Vehicle', 1),
+            ('1999', 'Aggravated Assault', 'Other', 2),
+            ('1999', 'Aggravated Assault', 'Personal Weapons', 1),
+            ('1999', 'Aggravated Assault', 'Unknown', 1)]
+
+        assert len(results) == len(expected)
+        for row, expect in zip(results, expected):
+            assert row == expect
+
+    @pytest.mark.parametrize('year', [1999, None])
+    @pytest.mark.parametrize('state_id', [47, None])
+    @pytest.mark.parametrize('offense_name', ['Aggravated Assault', None])
+    @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
+    def test_endpoint(self, app, year, state_id, offense_name, variable):
+        v = OffenseByOffenseTypeCountView(variable, year=year, state_id=state_id, offense_name=offense_name)
+        results = v.query({}).fetchall()
+        seen_values = set()
+        for row in results:
+            row_key = (row.year, row.offense_name, row[variable], )
+            assert row_key not in seen_values
+            seen_values.add(row_key)
+
+    @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
+    @pytest.mark.parametrize('variable', ['location_name'])
+    def test_endpoint_for_explorer_offense(self, app, explorer_offense, variable):
+        v = OffenseByOffenseTypeCountView(variable, year=1992, state_id=2, explorer_offense=explorer_offense)
+        results = v.query({}).fetchall()
+        if len(results) > 0:
+            seen_values = set()
+            for row in results:
+                row_key = (row.year, row.offense_name, row[variable], )
+                assert row_key not in seen_values
+                seen_values.add(row_key)
+
+    def test_explorer_offense_does_aggregation(self, app):
+        v = OffenseVictimCountView('sex_code', year=2014, state_id=26, explorer_offense='larceny')
+        results = v.query({}).fetchall()
+        expected = [
+            ('2014', 'larceny', 'F', 3),
+            ('2014', 'larceny', 'M', 3)]
         assert len(results) == len(expected)
         for row, expect in zip(results, expected):
             assert row == expect


### PR DESCRIPTION
Add a new `.../offenses` API endpoint on the `/offenses/count` method so you can do things like

'/offenses/count/national/location_name/offenses` (I know it's not great, but we can revise URLs later).