### PR TITLE
Fixing it so CSVs obey ordered=True from Marshmallow

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -6,6 +6,7 @@ from urllib import parse
 from decimal import Decimal
 from ast import literal_eval
 from functools import wraps
+from collections import OrderedDict
 
 import sqltap
 from flask import make_response, request
@@ -323,11 +324,12 @@ class CdeResource(MethodResource):
 
             # Serialize Data to flattened list of dicts.
             for d in data['results']:
-                to_csv.append(self._serialize_dict(d, {}))
+                to_csv.append(self._serialize_dict(d, OrderedDict()))
 
             # Fill in any missing keys.
-            empty = dict.fromkeys(set().union(*to_csv), "")
-            to_csv = [dict(empty, **d) for d in to_csv]
+            empty = OrderedDict.fromkeys(to_csv[0].keys(), "")
+            print(empty)
+            to_csv = [OrderedDict(empty, **d) for d in to_csv]
 
             # Generate CSV.
             # TODO: Sort by columns.

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -802,10 +802,12 @@ class IncidentViewCountSchema(Schema):
 class AgencyParticipationSchema(Schema):
     class Meta:
         model = newmodels.AgencyAnnualParticipation
-        fields = ('year', 'state_name', 'state_abbr', 'agency_id', 'agency_ori',
-                  'agency_name', 'agency_population', 'population_group_code',
-                  'population_group', 'reported', 'months_reported',
-                  'reported_nibrs', 'months_reported_nibrs', )
+        fields = ('state_name', 'state_abbr', 'year', 'agency_ori',
+                  'agency_name', 'reported', 'months_reported',
+                  'reported_nibrs', 'months_reported_nibrs',
+                  'population_group_code',
+                  'population_group', 'agency_population',)
+
         exclude = ('agency_id', )
         ordered = True
 

--- a/crime_data/settings.py
+++ b/crime_data/settings.py
@@ -15,7 +15,7 @@ class Config(object):
     DEBUG_TB_INTERCEPT_REDIRECTS = False
     CACHE_TYPE = 'simple'  # Can be "memcached", "redis", etc.
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-
+    # JSON_SORT_KEYS=False
 
 class ProdConfig(Config):
     """Production configuration."""


### PR DESCRIPTION
I wanted to make it so I could actually order the columns of the CSVs to match the ordering in Marshmallow, and this seems to work?

I hope this doesn't break anything else but this is the fun of not having great test coverage for base class methods like this