### PR TITLE
Reorder the columns in the agency participation CSV

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -117,10 +117,11 @@ def add_resources(app):
         return resp
 
     api.add_resource(crime_data.resources.agencies.AgenciesList, '/agencies/')
+    api.add_resource(crime_data.resources.agencies.AgenciesParticipation,
+                     '/agencies/participation',
+                     '/agencies/participation/')
     api.add_resource(crime_data.resources.agencies.AgenciesDetail,
                      '/agencies/<string:nbr>/')
-    api.add_resource(crime_data.resources.agencies.AgenciesParticipation,
-                     '/agencies/participation')
 
     # api.add_resource(crime_data.resources.incidents.IncidentsList,
     #                  '/incidents/')

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -46,7 +46,15 @@ class AgenciesDetail(AgenciesResource):
 
 class AgenciesParticipation(CdeResource):
 
-    schema = marshmallow_schemas.AgencyParticipationSchema(many=True)
+    schema = marshmallow_schemas.AgencyParticipationSchema(many=True,
+                                                           only=('state_name', 'year', 'agency_ori',
+                                                                 'agency_name', 'reported',
+                                                                 'months_reported',
+                                                                 'months_reported_nibrs',
+                                                                 'population_group_code',
+                                                                 'population_group',
+                                                                 'agency_population',)
+                                                        )
     tables = newmodels.AgencyAnnualParticipation
     is_groupable = False
 
@@ -56,19 +64,10 @@ class AgenciesParticipation(CdeResource):
         print(filters)
         if years:
             y = years[0]
-            data_year = y[2][0]
-            match = re.search('(\d{4})-(\d{4})', str(data_year))
-            if match:
-                data_years = list(range(int(match.group(1)), int(match.group(2))))
-            else:
-                data_years = [data_years]
-
-            print(data_year)
             filters = [x for x in filters if x[0] != 'year']
-            filters.append(('data_year', y[1], data_years))
+            filters.append(('data_year', y[1], y[2]))
 
         return filters
-
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
     @swagger.use_kwargs(marshmallow_schemas.ArgumentsSchema, apply=False, locations=['query'])


### PR DESCRIPTION
Fixes the CSV to match what is in https://github.com/18F/crime-data-explorer/issues/312#issuecomment-284599623

I also changed it to follow the same convention for specifying year ranges with `year>=2004&year<=2014` to have parity with other API methods. This will change how you call it @jeremiak  