### PR TITLE
National participation endpoint

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -19,6 +19,7 @@ import crime_data.resources.victims
 import crime_data.resources.cargo_theft
 import crime_data.resources.hate_crime
 import crime_data.resources.geo
+import crime_data.resources.participation
 
 from crime_data import commands
 from crime_data.assets import assets
@@ -154,6 +155,10 @@ def add_resources(app):
                      '/geo/counties/<string:fips>')
 
 
+    api.add_resource(crime_data.resources.participation.NationalParticipation,
+                     '/participation/national')
+
+
     api.add_resource(crime_data.resources.offenses.OffensesCountNational,
                      '/offenses/count/national/<string:variable>')
     api.add_resource(crime_data.resources.offenses.OffensesCountStates,
@@ -227,6 +232,7 @@ def add_resources(app):
     # docs.register(crime_data.resources.arrests.ArrestsCountByRace)
     # docs.register(crime_data.resources.arrests.ArrestsCountByEthnicity)
     # docs.register(crime_data.resources.arrests.ArrestsCountByAgeSex)
+    docs.register(crime_data.resources.participation.NationalParticipation)
     docs.register(crime_data.resources.meta.MetaDetail)
     docs.register(crime_data.resources.geo.StateDetail)
     docs.register(crime_data.resources.geo.CountyDetail)

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import sqltypes as st
 from psycopg2.extensions import AsIs
 
 from crime_data.common import models, newmodels
+from crime_data.common.models import RefState, RefCounty
 from crime_data.common.base import QueryTraits, Fields, ExplorerOffenseMapping
 from crime_data.extensions import db
 
@@ -23,8 +24,11 @@ def get_sql_count(q):
     return count
 
 
-class CdeRefState(models.RefState):
-    pass
+#class CdeRefState(RefState):
+#    pass
+
+#class CdeRefCounty(RefCounty):
+#    pass
 
 
 class CdeNibrsAge(models.NibrsAge):
@@ -69,12 +73,11 @@ class CdeRefAgencyCounty(models.RefAgencyCounty):
 class CdeParticipationRate(newmodels.ParticipationRate):
     """Class for querying the cde_participation_rate"""
 
-    def __init__(self, year=None, state_id=None, state_abbr=None, county_id=None, metro_div_id=None):
+    def __init__(self, year=None, state_id=None, state_abbr=None, county_id=None):
         self.year = year
         self.state_id = state_id
         self.state_abbr = state_abbr
         self.county_id = county_id
-        self.metro_div_id = metro_div_id
 
     @property
     def query(self):
@@ -92,10 +95,10 @@ class CdeParticipationRate(newmodels.ParticipationRate):
         return qry
 
 
-class CdeRefState(models.RefState):
+class CdeRefState(RefState):
     """A wrapper around the RefState model with extra finder methods"""
 
-    counties = db.relationship('CdeRefCounty', lazy='dynamic')
+    counties = db.relationship('RefCounty', lazy='dynamic')
 
     def get(state_id=None, abbr=None, fips=None):
         """
@@ -185,7 +188,7 @@ class CdeRefState(models.RefState):
         return CdeParticipationRate(state_id=self.state_id).query.order_by('data_year DESC').all()
 
 
-class CdeRefCounty(models.RefCounty):
+class CdeRefCounty(RefCounty):
     """A wrapper around the RefCounty model with extra methods."""
 
     def get(county_id=None, fips=None, name=None):

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -952,6 +952,15 @@ class ParticipationRateSchema(ma.ModelSchema):
     nibrs_reporting_rate = marsh_fields.Float()
 
 
+class StateParticipationRateSchema(ParticipationRateSchema):
+    class Meta:
+        fields = ('year', 'state_name', 'total_population', 'covered_population',
+                  'total_agencies', 'reporting_agencies', 'reporting_rate',
+                  'nibrs_reporting_agencies', 'nibrs_reporting_rate',)
+
+    state_name = marsh_fields.String()
+
+
 class StateDetailResponseSchema(ma.ModelSchema):
     """Response schema for the StateDetail API method."""
 

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -15,7 +15,7 @@ from sqlalchemy.sql import sqltypes
 from flask_restful import abort
 
 from crime_data.common import models
-from crime_data.common.models import RefAgency
+from crime_data.common.models import RefAgency, RefState, RefCounty
 from crime_data.extensions import db
 from sqlalchemy import or_
 
@@ -79,11 +79,13 @@ class ParticipationRate(db.Model):
     nibrs_reporting_rate = db.Column(db.Float)
     state_id = db.Column(db.Integer)
     county_id = db.Column(db.Integer)
+    state_name = db.Column(db.String)
+    county_name = db.Column(db.String)
 
-    state = relationship('RefState', foreign_keys=[state_id],
-                         primaryjoin='RefState.state_id == ParticipationRate.state_id')
-    county = relationship('RefCounty', foreign_keys=[county_id],
-                          primaryjoin='RefCounty.county_id == ParticipationRate.county_id')
+    # state = relationship('RefState', foreign_keys=[state_id],
+    #                     primaryjoin='RefState.state_id == ParticipationRate.state_id')
+    # county = relationship('RefCounty', foreign_keys=[county_id],
+    #                       primaryjoin='RefCounty.county_id == ParticipationRate.county_id')
 
 
 class CreatableModel:

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -80,6 +80,11 @@ class ParticipationRate(db.Model):
     state_id = db.Column(db.Integer)
     county_id = db.Column(db.Integer)
 
+    state = relationship('RefState', foreign_keys=[state_id],
+                         primaryjoin='RefState.state_id == ParticipationRate.state_id')
+    county = relationship('RefCounty', foreign_keys=[county_id],
+                          primaryjoin='RefCounty.county_id == ParticipationRate.county_id')
+
 
 class CreatableModel:
     @classmethod

--- a/crime_data/resources/geo.py
+++ b/crime_data/resources/geo.py
@@ -41,11 +41,11 @@ class CountyDetail(CdeResource):
 
 
 class StateParticipation(CdeResource):
-    schema = marshmallow_schemas.ParticipationRateSchema(many=True)
+    schema = marshmallow_schemas.StateParticipationRateSchema(many=True)
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
     @swagger.use_kwargs(marshmallow_schemas.ApiKeySchema, apply=False, locations=['query'])
-    @swagger.marshal_with(marshmallow_schemas.ParticipationRateSchema, apply=False)
+    @swagger.marshal_with(marshmallow_schemas.StateParticipationRateSchema, apply=False)
     @swagger.doc(tags=['geo'], description='Participation data for a state')
     @cache(max_age=DEFAULT_MAX_AGE, public=True)
     @tuning_page

--- a/crime_data/resources/participation.py
+++ b/crime_data/resources/participation.py
@@ -10,21 +10,24 @@ from crime_data.common import cdemodels, models, newmodels
 from crime_data.common import marshmallow_schemas
 from crime_data.common.base import CdeResource, tuning_page
 from crime_data.common.marshmallow_schemas import(
-    ArgumentsSchema, ApiKeySchema, ParticipationRateSchema
+    ArgumentsSchema, ApiKeySchema, StateParticipationRateSchema
 )
 
 class NationalParticipation(CdeResource):
     """Returns a collection of all state participation rates for each year"""
+    schema = marshmallow_schemas.StateParticipationRateSchema(many=True)
 
     @use_args(ArgumentsSchema)
     @swagger.use_kwargs(ApiKeySchema, apply=False, locations=['query'])
-    @swagger.marshal_with(ParticipationRateSchema, apply=False)
-    @swagger.doc(tags=['geo'], description='Participation data for a state')
+    @swagger.marshal_with(StateParticipationRateSchema, apply=False)
+    @swagger.doc(tags=['participation'], description='Participation data for all states')
     @cache(max_age=DEFAULT_MAX_AGE, public=True)
     @tuning_page
-    def get(self, args, state_id=None, state_abbr=None):
+    def get(self, args):
         self.verify_api_key(args)
 
-        rates = cdemodels.CdeParticipationRate.query.join('RefState').order_by('data_year DESC, state_name').all()
-        filename = 'participation_rates'.format(state.state_postal_abbr)
+        rates = cdemodels.CdeParticipationRate().query
+        rates = rates.filter(newmodels.ParticipationRate.state_id != None)
+        rates = rates.order_by('data_year DESC, state_name').all()
+        filename = 'participation_rates'
         return self.render_response(rates, args, csv_filename=filename)

--- a/crime_data/resources/participation.py
+++ b/crime_data/resources/participation.py
@@ -1,0 +1,30 @@
+import re
+
+from flask_restful import fields, marshal_with, reqparse
+from webargs.flaskparser import use_args
+import flask_apispec as swagger
+from crime_data.extensions import DEFAULT_MAX_AGE
+from flask.ext.cachecontrol import cache
+
+from crime_data.common import cdemodels, models, newmodels
+from crime_data.common import marshmallow_schemas
+from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.marshmallow_schemas import(
+    ArgumentsSchema, ApiKeySchema, ParticipationRateSchema
+)
+
+class NationalParticipation(CdeResource):
+    """Returns a collection of all state participation rates for each year"""
+
+    @use_args(ArgumentsSchema)
+    @swagger.use_kwargs(ApiKeySchema, apply=False, locations=['query'])
+    @swagger.marshal_with(ParticipationRateSchema, apply=False)
+    @swagger.doc(tags=['geo'], description='Participation data for a state')
+    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @tuning_page
+    def get(self, args, state_id=None, state_abbr=None):
+        self.verify_api_key(args)
+
+        rates = cdemodels.CdeParticipationRate.query.join('RefState').order_by('data_year DESC, state_name').all()
+        filename = 'participation_rates'.format(state.state_postal_abbr)
+        return self.render_response(rates, args, csv_filename=filename)

--- a/tests/functional/test_participation.py
+++ b/tests/functional/test_participation.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Functional tests using WebTest.
+
+See: http://webtest.readthedocs.org/
+"""
+
+class TestParticipationEndpoint:
+    def test_national_participation_endpoint(self, testapp):
+        res = testapp.get('/participation/national')
+        assert res.status_code == 200

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -111,10 +111,11 @@ class TestCdeRefState:
         assert state.reporting_agencies_for_year(test_year) == 13
         assert state.reporting_rate_for_year(test_year) == pytest.approx(0.382352941)
 
-        # select SUM(rcp.population)::text from ref_county_population rcp
-        # JOIN ref_county rc ON rc.county_id = rcp.county_id
-        # WHERE rc.state_id=55 AND rcp.data_year=1960
-        assert state.total_population_for_year(test_year) == 1244332
+        # select SUM(rac.population)
+        # from ref_agency_county rac
+        # JOIN ref_county rc ON rac.county_id = rc.county_id
+        # WHERE rc.state_id=55 and rac.data_year=1960;
+        assert state.total_population_for_year(test_year) == 706802
 
         # select SUM(rac.population)::text
         # from ref_agency_county rac

--- a/tests/unit/test_newmodels.py
+++ b/tests/unit/test_newmodels.py
@@ -37,7 +37,7 @@ class TestParticipationRate:
         assert q.reporting_rate == 1
         assert q.nibrs_reporting_agencies == 1
         assert q.nibrs_reporting_rate == 1
-        assert q.total_population == None
+        assert q.total_population == 80007
         assert q.covered_population == 0
 
 


### PR DESCRIPTION
This pull request fixes two things:

1. Changes total populations for states and counties to be a sum of agency population instead of county population.
2. Adds `state_name` and `county_name` to the `cde_participation_rate` table so I don't need to join because SqlAlchemy is terrible.

This adds a new endpoint at `/participation/national`