### PR TITLE
Add CHANGELOG for 2017-03-15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [2017-03-15]
+### Added
+- Caching headers to API responses ([#395](https://github.com/18F/crime-data-api/issues/395))
+- National participation endpoint ([#415](https://github.com/18F/crime-data-api/pull/415))
+
+### Changed
+- Reorder columns in agency participation CSV ([#414](https://github.com/18F/crime-data-api/pull/414))
+
+### Fixed
+- Arson data included in summary data ([#399](https://github.com/18F/crime-data-api/issues/399))
+- Fix "R" and "U" offender relationship values ([#408](https://github.com/18F/crime-data-api/issues/408))
+- Recompute state and county populations using ref_agency_population ([#412](https://github.com/18F/crime-data-api/issues/412))
+- Rebuild participation table with the same renaming strategy as `reta_month_offense_subcat_summary` ([#417](https://github.com/18F/crime-data-api/issues/417))
+- Participation table also computes covered population for NIBRS ([](https://github.com/18F/crime-data-api/issues/419))
+- National endpoint returns aggregated data ([#420](https://github.com/18F/crime-data-api/issues/420))


### PR DESCRIPTION
@harrisj and @cacraig, please let me know if I missed anything!

I generated the change log from reviewing the issues that were closed over the past two weeks and this commit compare: https://github.com/18F/crime-data-api/compare/c04591e2514c3bc223ae6c88e318adac1d8a1acb...e99e7eb2de2a7b46c64cc1f36906fc809d22e963

I didn't want to tag the commit yet in case I missed something, so once I get the 👍 from ya'll I will tag the commit with `v2017-03-15`.