### PR TITLE
Allow authentication via HTTP X-API-KEY header instead

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -22,7 +22,6 @@ session = db.session
 
 COUNT_QUERY_THRESHOLD = 1000
 
-
 def tuning_page(f):
     @wraps(f)
     def decorated_get(*args, **kwargs):
@@ -328,7 +327,6 @@ class CdeResource(MethodResource):
 
             # Fill in any missing keys.
             empty = OrderedDict.fromkeys(to_csv[0].keys(), "")
-            print(empty)
             to_csv = [OrderedDict(empty, **d) for d in to_csv]
 
             # Generate CSV.
@@ -468,10 +466,10 @@ class CdeResource(MethodResource):
                 if 'credentials' in u
             ]
             key = creds[0]['API_KEY']
-            test_key = args.get('api_key')
+            test_key = args.get('api_header_key', None) or args.get('api_key')
 
-            if test_key != key and parse.unquote(test_key) != key:
-                abort(401, message='Use correct `api_key` argument')
+            if test_key is None or (test_key != key and parse.unquote(test_key) != key):
+                abort(401, message='Use correct `api_key` argument or X-API-KEY HTTP header')
 
     def _parse_inequality_operator(self, k, v):
         """

--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -28,11 +28,13 @@ class SchemaFormater(object):
 
 
 class ApiKeySchema(Schema):
-    if os.getenv('VCAP_APPLICATION'):
-        api_key = marsh_fields.String(
-            required=True,
-            error_messages={'required': 'Get API key from Catherine'})
-
+    api_key = marsh_fields.String(
+        required=False,
+        error_messages={'required': 'Get API key from Catherine'})
+    api_header_key = marsh_fields.String(
+        load_from='X-API-KEY',
+        required=False,
+        location='headers')
 
 # Schemas for request parsing
 class ArgumentsSchema(ApiKeySchema):

--- a/tests/functional/test_authentication.py
+++ b/tests/functional/test_authentication.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Functional tests using WebTest.
+
+See: http://webtest.readthedocs.org/
+"""
+
+import json
+import crime_data.common.credentials as c
+
+class TestAuthentication:
+    """For testing authentication"""
+
+    def test_header_login(self, monkeypatch, testapp):
+        TEST_VCAP = {
+            'user-provided': [
+                {
+                    'credentials': {
+                        'API_KEY': 'key'
+                    }
+                }
+            ]
+        }
+        monkeypatch.setenv('VCAP_SERVICES', json.dumps(TEST_VCAP))
+        monkeypatch.setenv('VCAP_APPLICATION', "foo")
+        c.service_credentials.cache_clear()
+
+        res = testapp.get('/geo/states/WY', headers={'X-API-KEY': 'key'})
+        assert res.status_code == 200
+
+    def test_query_login(self, monkeypatch, testapp):
+        TEST_VCAP = {
+            'user-provided': [
+                {
+                    'credentials': {
+                        'API_KEY': 'key'
+                    }
+                }
+            ]
+        }
+        monkeypatch.setenv('VCAP_SERVICES', json.dumps(TEST_VCAP))
+        monkeypatch.setenv('VCAP_APPLICATION', "foo")
+        c.service_credentials.cache_clear()
+
+        res = testapp.get('/geo/states/WY?api_key=key')
+        assert res.status_code == 200
+
+    def test_missing_login(self, monkeypatch, testapp):
+        TEST_VCAP = {
+            'user-provided': [
+                {
+                    'credentials': {
+                        'API_KEY': 'key'
+                    }
+                }
+            ]
+        }
+        monkeypatch.setenv('VCAP_SERVICES', json.dumps(TEST_VCAP))
+        monkeypatch.setenv('VCAP_APPLICATION', "foo")
+        c.service_credentials.cache_clear()
+
+        res = testapp.get('/geo/states/WY', expect_errors=True)
+        assert res.status_code == 401
+
+    def test_optional_login(self, testapp):
+        res = testapp.get('/geo/states/WY')
+        assert res.status_code == 200


### PR DESCRIPTION
Fixes #434 

This is necessary to prevent a situation where api.data.gov might accidentally reveal the API key