### PR TITLE
Api usability

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -127,7 +127,7 @@ def add_resources(app):
     # api.add_resource(crime_data.resources.incidents.IncidentsList,
     #                  '/incidents/')
     api.add_resource(crime_data.resources.incidents.CachedIncidentsCount,
-                     '/incidents/count/')
+                     '/incidents/count/', '/counts')
     # api.add_resource(crime_data.resources.incidents.IncidentsDetail,
     #                  '/incidents/<int:id>/')
     api.add_resource(crime_data.resources.offenses.OffensesList, '/offenses/')

--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -436,12 +436,17 @@ class CdeResource(MethodResource):
 
         serialized = self._serialize(paginated)
 
+        max_page = math.ceil(count / args['per_page'])
+
+        if args['page'] > max_page:
+            # Let user know they have reached the page max.
+            args['page'] = max_page
         return {
             'results': serialized,
             'pagination': {
                 'count': count,
                 'page': args['page'],
-                'pages': math.ceil(count / args['per_page']),
+                'pages': max_page,
                 'per_page': args['per_page'],
             },
         }

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -1115,7 +1115,8 @@ class MultiYearCountView(object):
         self.state_id = state_id
 
         if state_abbr and state_id is None:
-            self.state_id = CdeRefState.get(abbr=state_abbr).one().state_id
+            # Select State ID for State Abbreviation.
+            self.state_id = CdeRefState.get(abbr=state_abbr.upper()).one().state_id
             
         self.county_id = county_id
         self.field = field
@@ -1265,7 +1266,8 @@ class OffenseSubCountView(object):
         self.state_id = state_id
 
         if state_abbr and state_id is None:
-            self.state_id = CdeRefState.get(abbr=state_abbr).one().state_id
+            # Select State ID for State Abbreviation.
+            self.state_id = CdeRefState.get(abbr=state_abbr.upper()).one().state_id
 
         self.county_id = county_id
         self.field = field

--- a/crime_data/resources/cargo_theft.py
+++ b/crime_data/resources/cargo_theft.py
@@ -27,7 +27,7 @@ class CargoTheftsCountStates(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The state ID from ref_state'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.CargoTheftCountView.VARIABLES}},
@@ -113,7 +113,7 @@ class CargoTheftOffenseSubcounts(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The ID for a state to limit the query to'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.OffenseCargoTheftCountView.VARIABLES}},

--- a/crime_data/resources/hate_crime.py
+++ b/crime_data/resources/hate_crime.py
@@ -26,7 +26,7 @@ class HateCrimesCountStates(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The state ID from ref_state'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.HateCrimeCountView.VARIABLES}},
@@ -107,7 +107,7 @@ class HateCrimeOffenseSubcounts(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The ID for a state to limit the query to'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.OffenseHateCrimeCountView.VARIABLES}},

--- a/crime_data/resources/offenders.py
+++ b/crime_data/resources/offenders.py
@@ -122,12 +122,13 @@ class OffenderOffenseSubcounts(CdeResource):
     @swagger.marshal_with(marshmallow_schemas.OffenseCountViewResponseSchema, apply=False)
     @cache(max_age=DEFAULT_MAX_AGE, public=True)
     @tuning_page
-    def get(self, args, variable, state_id=None):
+    def get(self, args, variable, state_id=None, state_abbr=None):
         self.verify_api_key(args)
         model = cdemodels.OffenseOffenderCountView(variable,
                                                    year=args.get('year', None),
                                                    offense_name=args.get('offense_name', None),
                                                    explorer_offense=args.get('explorer_offense', None),
-                                                   state_id=state_id)
+                                                   state_id=state_id,
+                                                   state_abbr=state_abbr)
         results = model.query(args)
         return self.with_metadata(results.fetchall(), args)

--- a/crime_data/resources/offenders.py
+++ b/crime_data/resources/offenders.py
@@ -54,7 +54,7 @@ class OffendersCountStates(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The state ID from ref_state'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'enum': cdemodels.OffenderCountView.VARIABLES}},
         tags=['offenders'],
@@ -109,7 +109,7 @@ class OffenderOffenseSubcounts(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The ID for a state to limit the query to'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'explorer_offense': {'description': 'A offense class used by the explorer',
                                      'enum': ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys()},
                 'variable': {'description': 'A variable to group by',

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -71,7 +71,7 @@ class OffensesCountStates(CdeResource):
                         apply=False)
     @swagger.doc(
         tags=['offenses'],
-        params={'state_id': {'description': 'The state ID from ref_county'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.OffenseCountView.VARIABLES}},
@@ -128,7 +128,7 @@ class OffenseByOffenseTypeSubcounts(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The ID for a state to limit the query to'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.OffenseByOffenseTypeCountView.VARIABLES}},

--- a/crime_data/resources/victims.py
+++ b/crime_data/resources/victims.py
@@ -59,7 +59,7 @@ class VictimsCountStates(CdeResource):
                         apply=False)
     @swagger.doc(
         tags=['victims'],
-        params={'state_id': {'description': 'The state ID from ref_county'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.VictimCountView.VARIABLES}},
@@ -116,7 +116,7 @@ class VictimOffenseSubcounts(CdeResource):
                         locations=['query'],
                         apply=False)
     @swagger.doc(
-        params={'state_id': {'description': 'The ID for a state to limit the query to'},
+        params={'state_abbr': {'description': 'The two letter State Abbreviation'},
                 'variable': {'description': 'A variable to group by',
                              'locations': ['path'],
                              'enum': cdemodels.OffenseVictimCountView.VARIABLES}},

--- a/tests/functional/test_offense_by_offense_types.py
+++ b/tests/functional/test_offense_by_offense_types.py
@@ -23,6 +23,15 @@ class TestOffenseByOffenseTypesEndpoint:
         for r in res.json['results']:
             assert 'count' in r
 
+
+    @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
+    def test_offenses_endpoint_with_postal_code(self, testapp, variable):
+        url = '/offenses/count/states/AR/{}/offenses?year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
     @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
     def test_offenses_endpoint_with_state_year_offense(self, testapp, variable):
         url = '/offenses/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)

--- a/tests/functional/test_offense_offenders.py
+++ b/tests/functional/test_offense_offenders.py
@@ -24,7 +24,7 @@ class TestOffendersOffensesEndpoint:
             assert 'count' in r
 
     @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
-    def test_offenders_offenses_endpoint_with_state_postal_code(self, testapp):
+    def test_offenders_offenses_endpoint_with_state_postal_code(self, testapp, variable):
         url = '/offenders/count/states/AR/{}/offenses?year=2014'.format(variable)
         res = testapp.get(url)
         assert 'pagination' in res.json

--- a/tests/functional/test_offense_offenders.py
+++ b/tests/functional/test_offense_offenders.py
@@ -16,7 +16,7 @@ class TestOffendersOffensesEndpoint:
             assert 'count' in r
 
     @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
-    def test_victims_offenses_endpoint_with_just_state_year(self, testapp, variable):
+    def test_offenders_offenses_endpoint_with_just_state_year(self, testapp, variable):
         url = '/offenders/count/states/43/{}/offenses?year=2014'.format(variable)
         res = testapp.get(url)
         assert 'pagination' in res.json
@@ -24,7 +24,15 @@ class TestOffendersOffensesEndpoint:
             assert 'count' in r
 
     @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
-    def test_victims_offenses_endpoint_with_state_year_offense(self, testapp, variable):
+    def test_offenders_offenses_endpoint_with_state_postal_code(self, testapp):
+        url = '/offenders/count/states/AR/{}/offenses?year=2014'.format(variable)
+        res = testapp.get(url)
+        assert 'pagination' in res.json
+        for r in res.json['results']:
+            assert 'count' in r
+
+    @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
+    def test_offenders_offenses_endpoint_with_state_year_offense(self, testapp, variable):
         url = '/offenders/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)
         res = testapp.get(url)
         assert 'pagination' in res.json
@@ -33,7 +41,7 @@ class TestOffendersOffensesEndpoint:
 
     @pytest.mark.parametrize('variable', OffenseOffenderCountView.VARIABLES)
     @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
-    def test_victims_offenses_endpoint_with_state_year_explorer_offense(self, testapp, variable, explorer_offense):
+    def test_offenders_offenses_endpoint_with_state_year_explorer_offense(self, testapp, variable, explorer_offense):
         url = '/offenders/count/states/43/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
         res = testapp.get(url)
         assert 'pagination' in res.json


### PR DESCRIPTION
FINALLY. SOMETHING THAT IS NOT A SQL SCRIPT.
  
- Modified swagger generation to specify state_abbr case insensitive instead of state_id @harrisj    This will probably need to change in your swagger work.  
- state_id still works, so it can be either state_id or abbr.  
- Added route for mapping /incidents/count to /counts. 
- Added page cap for paginated requests.  
  
Addresses: #281 ,  #336,  and #403 .  