### PR TITLE
Clean up participation endpoints

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -117,9 +117,9 @@ def add_resources(app):
         return resp
 
     api.add_resource(crime_data.resources.agencies.AgenciesList, '/agencies/')
-    api.add_resource(crime_data.resources.agencies.AgenciesParticipation,
+    api.add_resource(crime_data.resources.participation.AgenciesParticipation,
                      '/agencies/participation',
-                     '/agencies/participation/')
+                     '/participation/agencies')
     api.add_resource(crime_data.resources.agencies.AgenciesDetail,
                      '/agencies/<string:nbr>/')
 
@@ -147,9 +147,10 @@ def add_resources(app):
                      '/meta/<path:endpoint>')
     api.add_resource(crime_data.resources.geo.StateDetail,
                      '/geo/states/<string:id>')
-    api.add_resource(crime_data.resources.geo.StateParticipation,
+    api.add_resource(crime_data.resources.participation.StateParticipation,
                      '/geo/states/<int:state_id>/participation',
-                     '/geo/states/<string:state_abbr>/participation')
+                     '/geo/states/<string:state_abbr>/participation',
+                     '/participation/states/<string:state_abbr>')
 
     api.add_resource(crime_data.resources.geo.CountyDetail,
                      '/geo/counties/<string:fips>')

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -33,35 +33,3 @@ class AgenciesDetail(AgenciesResource):
         self.verify_api_key(args)
         agency = cdemodels.CdeRefAgency.get(nbr)
         return self.with_metadata(agency, args)
-
-
-class AgenciesParticipation(CdeResource):
-
-    schema = marshmallow_schemas.AgencyParticipationSchema(many=True,
-                                                           only=('state_name', 'year', 'agency_ori',
-                                                                 'agency_name', 'reported',
-                                                                 'months_reported',
-                                                                 'months_reported_nibrs',
-                                                                 'population_group_code',
-                                                                 'population_group',
-                                                                 'agency_population',)
-                                                        )
-    tables = newmodels.AgencyAnnualParticipation
-    is_groupable = False
-
-    def postprocess_filters(self, filters, args):
-        years = [x for x in filters if x[0] == 'year']
-
-        print(filters)
-        if years:
-            y = years[0]
-            filters = [x for x in filters if x[0] != 'year']
-            filters.append(('data_year', y[1], y[2]))
-
-        return filters
-
-    @use_args(marshmallow_schemas.ArgumentsSchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
-    @tuning_page
-    def get(self, args):
-        return self._get(args, csv_filename='agency_participation')

--- a/crime_data/resources/geo.py
+++ b/crime_data/resources/geo.py
@@ -29,18 +29,3 @@ class CountyDetail(CdeResource):
         self.verify_api_key(args)
         county = cdemodels.CdeRefCounty.get(fips=fips).one()
         return jsonify(self.schema.dump(county).data)
-
-
-class StateParticipation(CdeResource):
-    schema = marshmallow_schemas.StateParticipationRateSchema(many=True)
-
-    @use_args(marshmallow_schemas.ArgumentsSchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
-    @tuning_page
-    def get(self, args, state_id=None, state_abbr=None):
-        self.verify_api_key(args)
-
-        state = cdemodels.CdeRefState.get(abbr=state_abbr, state_id=state_id).one()
-        rates = cdemodels.CdeParticipationRate(state_id=state.state_id).query.order_by('data_year DESC').all()
-        filename = '{}_state_participation'.format(state.state_postal_abbr)
-        return self.render_response(rates, args, csv_filename=filename)

--- a/crime_data/resources/participation.py
+++ b/crime_data/resources/participation.py
@@ -12,6 +12,22 @@ from crime_data.common.marshmallow_schemas import(
     ArgumentsSchema, ApiKeySchema, StateParticipationRateSchema
 )
 
+
+class StateParticipation(CdeResource):
+    schema = marshmallow_schemas.StateParticipationRateSchema(many=True)
+
+    @use_args(marshmallow_schemas.ArgumentsSchema)
+    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @tuning_page
+    def get(self, args, state_id=None, state_abbr=None):
+        self.verify_api_key(args)
+
+        state = cdemodels.CdeRefState.get(abbr=state_abbr, state_id=state_id).one()
+        rates = cdemodels.CdeParticipationRate(state_id=state.state_id).query.order_by('data_year DESC').all()
+        filename = '{}_state_participation'.format(state.state_postal_abbr)
+        return self.render_response(rates, args, csv_filename=filename)
+
+
 class NationalParticipation(CdeResource):
     """Returns a collection of all state participation rates for each year"""
     schema = marshmallow_schemas.ParticipationRateSchema(many=True)
@@ -28,3 +44,36 @@ class NationalParticipation(CdeResource):
         rates = rates.order_by('data_year DESC').all()
         filename = 'participation_rates'
         return self.render_response(rates, args, csv_filename=filename)
+
+
+class AgenciesParticipation(CdeResource):
+
+    schema = marshmallow_schemas.AgencyParticipationSchema(many=True,
+                                                           only=('state_name', 'state_abbr', 'year', 'agency_ori',
+                                                                 'agency_name', 'reported',
+                                                                 'months_reported',
+                                                                 'months_reported_nibrs',
+                                                                 'population_group_code',
+                                                                 'population_group',
+                                                                 'agency_population',)
+                                                          )
+
+    tables = newmodels.AgencyAnnualParticipation
+    is_groupable = False
+
+    def postprocess_filters(self, filters, args):
+        years = [x for x in filters if x[0] == 'year']
+
+        print(filters)
+        if years:
+            y = years[0]
+            filters = [x for x in filters if x[0] != 'year']
+            filters.append(('data_year', y[1], y[2]))
+
+        return filters
+
+    @use_args(marshmallow_schemas.ArgumentsSchema)
+    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @tuning_page
+    def get(self, args):
+        return self._get(args, csv_filename='agency_participation')

--- a/crime_data/static/swagger.json
+++ b/crime_data/static/swagger.json
@@ -125,6 +125,64 @@
         "pattern": "[A-Z]{2}"
       }
     },
+    "stateNameParam": {
+      "in": "query",
+      "name": "state_name",
+      "description": "The name of the state",
+      "required": false,
+      "type": "array",
+      "collectionFormat": "csv",
+      "items": {
+        "type": "string"
+      }
+    },
+    "agencyOriParam": {
+      "in": "query",
+      "name": "agency_ori",
+      "description": "The ORI of the agency. You can provide multiple arguments.",
+      "required": false,
+      "type": "array",
+      "collectionFormat": "csv",
+      "items": {
+        "type": "string",
+        "pattern": "[A-Z0-9]{9}"
+      }
+    },
+    "agencyNameParam": {
+      "in": "query",
+      "name": "agency_name",
+      "description": "The name of the agency. Currently only supports exact matches.",
+      "required": false,
+      "type": "string"
+    },
+    "reportedParam": {
+      "in": "query",
+      "name": "reported",
+      "description": "If the agency has reported either SRS or NIBRS. This makes the most sense when combined with a `year` argument.",
+      "required": false,
+      "type": "string"
+    },
+    "reportedNibrsParam": {
+      "in": "query",
+      "name": "reported_nibrs",
+      "description": "If the agency has reported either NIBRS. This makes the most sense when combined with a `year` argument.",
+      "required": false,
+      "type": "string"
+    },
+    "monthsReportedParam": {
+      "in": "query",
+      "name": "reported",
+      "description": "Months in a year that the agency has reported either SRS or NIBRS. This makes the most sense when combined with a `year` argument.",
+      "required": false,
+      "type": "string"
+    },
+    "monthsReportedNibrsParam": {
+      "in": "query",
+      "name": "reported_nibrs",
+      "description": "Months in a year that an agency has reported NIBRS. This makes the most sense when combined with a `year` argument.",
+      "required": false,
+      "type": "string"
+    },
     "statePathParam": {
       "in": "path",
       "name": "state_id",
@@ -375,6 +433,73 @@
         }
       },
       "type": "object"
+    },
+    "AgencyParticipation": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "year": {
+          "format": "int32",
+          "type": ["integer", "null"],
+          "description": "The year these participation details are for",
+          "minimum": 1960
+        },
+        "state_name": {
+          "type": "string",
+          "description": "The name of the state the agency is located in"
+        },
+        "state_abbr": {
+          "type": ["string", "null"],
+          "pattern": "[A-Z]{2}",
+          "decription": "The two-letter postal abbreviation for the state"
+        },
+        "agency_ori": {
+          "type": ["string", "null"],
+          "pattern": "[A-Z0-9]{9}",
+          "description": "The 9-character ORI for the agency"
+        },
+        "agency_name": {
+          "type": ["string", "null"],
+          "description": "The agency's name"
+        },
+        "agency_population": {
+          "type": ["number", "null"],
+          "description": "The unique population within the jurisdiction for the agency. The FBI UCR program does not overlap populations even though agency jurisdictions might overlap. This means that some agencies like state highway patrols or transit police might be assigned a population of 0, and that is not a bug",
+          "minimum": 0
+        },
+        "population_group_code": {
+          "type": ["string", "null"],
+          "description": "The FBI code for the population group the agency belongs to. For a full listing of all population codes, call the `/codes/ref_population_group`"
+        },
+        "population_group": {
+          "type": ["string", "null"],
+          "description": "The name for the population group the agency belongs to"
+        },
+        "reported": {
+          "type": ["integer", "null"],
+          "description": "This is 1 if agency reported either SRS or NIBRS at least once in the given year",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "months_reported": {
+          "type": "integer",
+          "description": "How many months the agency filed a crime report in the given year",
+          "minimum": 0,
+          "maximum": 12
+        },
+        "reported_nibrs": {
+          "type": "integer",
+          "description": "This is 1 if agency reported to NIBRS at least once in the given year",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "months_reported_nibrs": {
+          "type": "integer",
+          "description": "How many months the agency filed a NIBRS crime report in the given year",
+          "minimum": 0,
+          "maximum": 12
+        }
+      }
     },
     "ParticipationRate": {
       "type": "object",
@@ -683,7 +808,7 @@
         }
       }
     },
-    "/geo/states/{state_id}/participation": {
+    "/participation/states/{state_id}": {
       "get": {
         "tags": [
           "state",
@@ -727,6 +852,87 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/definitions/StateParticipationRate"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The standard error response",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/participation/agencies": {
+      "get": {
+        "tags": [
+          "participation"
+        ],
+        "description": "Returns participation details for agencies",
+        "parameters": [
+          {
+            "$ref": "#/parameters/aggregateManyParam"
+          },
+          {
+            "$ref": "#/parameters/fieldsParam"
+          },
+          {
+            "$ref": "#/parameters/pageParam"
+          },
+          {
+            "$ref": "#/parameters/perPageParam"
+          },
+          {
+            "$ref": "#/parameters/outputParam"
+          },
+          {
+            "$ref": "#/parameters/yearParam"
+          },
+          {
+            "$ref": "#/parameters/stateNameParam"
+          },
+          {
+            "$ref": "#/parameters/stateParam"
+          },
+          {
+            "$ref": "#/parameters/agencyOriParam"
+          },
+          {
+            "$ref": "#/parameters/agencyNameParam"
+          },
+          {
+            "$ref": "#/parameters/reportedParam"
+          },
+          {
+            "$ref": "#/parameters/reportedNibrsParam"
+          },
+          {
+            "$ref": "#/parameters/monthsReportedParam"
+          },
+          {
+            "$ref": "#/parameters/monthsReportedNibrsParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "For success, return a paginated list of agency participation detail. With no parameters, this can get quite large, but you can provide filters to limit to specific fields.",
+            "schema": {
+              "type": "object",
+              "required": [
+                "pagination",
+                "results"
+              ],
+              "properties": {
+                "pagination": {
+                  "$ref": "#/definitions/Pagination"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/AgencyParticipation"
                   }
                 }
               }

--- a/tests/functional/test_geo.py
+++ b/tests/functional/test_geo.py
@@ -14,9 +14,3 @@ class TestGeoEndpoint:
     def test_county_detail_endpoint(self, testapp, swagger):
         res = testapp.get('/geo/counties/39043')
         assert res.status_code == 200
-
-    def test_state_participation_endpoint(self, testapp, swagger):
-        res = testapp.get('/geo/states/NY/participation')
-        print(res.json['results'][0])
-        assert res.status_code == 200
-        validate_api_call(swagger, raw_request=res.request, raw_response=res)

--- a/tests/functional/test_participation.py
+++ b/tests/functional/test_participation.py
@@ -3,10 +3,55 @@
 
 See: http://webtest.readthedocs.org/
 """
+import pytest
 from flex.core import validate_api_call
 
 class TestParticipationEndpoint:
     def test_national_participation_endpoint(self, testapp, swagger):
         res = testapp.get('/participation/national')
         assert res.status_code == 200
+        validate_api_call(swagger, raw_request=res.request, raw_response=res)
+
+    def test_state_participation_endpoint(self, testapp, swagger):
+        res = testapp.get('/participation/states/NY')
+        assert res.status_code == 200
+        validate_api_call(swagger, raw_request=res.request, raw_response=res)
+
+    def test_agencies_endpoint(self, testapp, swagger):
+        res = testapp.get('/participation/agencies?year=2014')
+        assert res.status_code == 200
+        validate_api_call(swagger, raw_request=res.request, raw_response=res)
+
+    @pytest.mark.parametrize('filter,value', [
+        ('year', 2004),
+        ('state_name', 'Massachusetts'),
+        ('state_abbr', 'OH'),
+        ('agency_ori', 'TNMPD0000'),
+        ('reported', 1)
+    ])
+    def test_agencies_endpoint_with_filter(self, testapp, swagger, filter, value):
+        res = testapp.get('/participation/agencies?{}={}'.format(filter, value))
+        assert res.status_code == 200
+        assert res.json['results'][0][filter] == value
+        validate_api_call(swagger, raw_request=res.request, raw_response=res)
+
+    @pytest.mark.parametrize('filter,value', [
+        ('year', 2004),
+        ('months_reported', 3),
+        ('months_reported_nibrs', 1)
+    ])
+    def test_agencies_endpoint_with_filter_comparison(self, testapp, swagger, filter, value):
+        res = testapp.get('/participation/agencies?{}<={}'.format(filter, value))
+        assert res.status_code == 200
+        assert int(res.json['results'][0][filter]) <= value
+        validate_api_call(swagger, raw_request=res.request, raw_response=res)
+
+        res = testapp.get('/participation/agencies?{}={}'.format(filter, value))
+        assert res.status_code == 200
+        assert int(res.json['results'][0][filter]) == value
+        validate_api_call(swagger, raw_request=res.request, raw_response=res)
+
+        res = testapp.get('/participation/agencies?{}>{}'.format(filter, value))
+        assert res.status_code == 200
+        assert int(res.json['results'][0][filter]) > value
         validate_api_call(swagger, raw_request=res.request, raw_response=res)


### PR DESCRIPTION
Fixing some issues around participation noted in #406. Also, noticed some missing tests.

This still keeps the old API endpoints for compatibility, but we will want to remove those eventually.