### PR TITLE
Close connections always.

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -375,7 +375,9 @@ class CdeResource(Resource):
             paginated = results
             count = len(paginated)
             pass
-
+        # Close session connection - release to pool.
+        session.close()
+        
         serialized = self._serialize(paginated)
 
         max_page = math.ceil(count / args['per_page'])

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -540,12 +540,18 @@ class TableFamily:
         """Returns a finalized SQLAlchemy Query object"""
         self._build_map()
         # self.print_map() # - uncomment to generate JSON
-        qry = self.base_query()
-        for table in self.tables:
-            if table.join is None:
-                qry = qry.outerjoin(table.table)
-            else:
-                qry = qry.outerjoin(table.table, table.join)
+        try:
+            qry = self.base_query()
+            for table in self.tables:
+                if table.join is None:
+                    qry = qry.outerjoin(table.table)
+                else:
+                    qry = qry.outerjoin(table.table, table.join)
+        except Exception, e:
+            session.rollback()
+            session.close()
+            raise e
+
         return qry
 
     def print_map(self):
@@ -986,6 +992,7 @@ class MultiYearCountView(object):
                 qry = session.execute(base_query, param_dict)
         except Exception as e:
             session.rollback()
+            session.close()
             raise e
         return qry
 
@@ -1147,6 +1154,7 @@ class OffenseSubCountView(object):
 
         except Exception as e:
             session.rollback()
+            session.close()
             raise e
         return qry
 

--- a/crime_data/common/cdemodels.py
+++ b/crime_data/common/cdemodels.py
@@ -547,7 +547,7 @@ class TableFamily:
                     qry = qry.outerjoin(table.table)
                 else:
                     qry = qry.outerjoin(table.table, table.join)
-        except Exception, e:
+        except Exception as e:
             session.rollback()
             session.close()
             raise e


### PR DESCRIPTION
The problem: We are getting a bunch of "Idle in Transaction" queries in the DB because something is causing requests to die/timeout. The connection is being left open without issuing a commit, or an END for the transaction. - This concerns mostly anything querying against the reta_month summary tables.

This is the simplest way to handle this is to close off every connection at the end of a transaction. If this doesn't work then we may need to disable the SQLAlchemy connection pooling. 