### PR TITLE
Add sample data for Rhode Island 2014 crime

### DIFF
--- a/dba/after_load/create_reta_summary.sql
+++ b/dba/after_load/create_reta_summary.sql
@@ -48,12 +48,12 @@ FROM
            ros.offense_subcat_name AS offense_subcat,
            ros.offense_subcat_code
     FROM   reta_month_offense_subcat rmos
-    LEFT OUTER JOIN   reta_offense_subcat ros ON (rmos.offense_subcat_id = ros.offense_subcat_id)
-    LEFT OUTER JOIN   reta_offense ro ON (ros.offense_id = ro.offense_id)
-    LEFT OUTER JOIN   reta_offense_category roc ON (ro.offense_category_id = roc.offense_category_id)
+    JOIN   reta_offense_subcat ros ON (rmos.offense_subcat_id = ros.offense_subcat_id)
+    JOIN   reta_offense ro ON (ros.offense_id = ro.offense_id)
+    JOIN   reta_offense_category roc ON (ro.offense_category_id = roc.offense_category_id)
     LEFT OUTER JOIN   offense_classification oc ON (ro.classification_id = oc.classification_id)
-    LEFT OUTER JOIN   reta_month rm ON (rmos.reta_month_id = rm.reta_month_id)
-    LEFT OUTER JOIN   ref_agency ra ON (rm.agency_id = ra.agency_id)
+    JOIN   reta_month rm ON (rmos.reta_month_id = rm.reta_month_id)
+    JOIN   ref_agency ra ON (rm.agency_id = ra.agency_id)
     LEFT OUTER JOIN   ref_state rs ON (ra.state_id = rs.state_id))
   UNION
     (SELECT
@@ -74,8 +74,8 @@ FROM
             asuc.subcategory_code AS offense_subcat_code
     FROM arson_month_by_subcat ambs
     JOIN   arson_month am ON ambs.arson_month_id = am.arson_month_id
-    LEFT OUTER JOIN   arson_subcategory asuc ON ambs.subcategory_id = asuc.subcategory_id
-    LEFT OUTER JOIN   ref_agency ra ON am.agency_id = ra.agency_id
+    JOIN   arson_subcategory asuc ON ambs.subcategory_id = asuc.subcategory_id
+    JOIN   ref_agency ra ON am.agency_id = ra.agency_id
     LEFT OUTER JOIN   ref_state rs ON ra.state_id = rs.state_id)
 ) AS u
     GROUP BY CUBE (year, month, (state_name, state)),

--- a/dba/after_load/participation_table.sql
+++ b/dba/after_load/participation_table.sql
@@ -1,7 +1,7 @@
 SET work_mem='4096MB'; -- Go Super Saiyan.
 
 CREATE materialized VIEW cde_annual_participation_temp AS
-SELECT rm.data_year,
+SELECT DISTINCT rm.data_year,
 rs.state_name AS state_name,
 rs.state_postal_abbr AS state_abbr,
 ra.agency_id,
@@ -23,7 +23,7 @@ LEFT OUTER JOIN nibrs_month nm ON nm.agency_id = rm.agency_id AND nm.data_year =
 LEFT OUTER JOIN ref_agency_population rap ON rap.agency_id = rm.agency_id AND rap.data_year = rm.data_year
 LEFT OUTER JOIN ref_population_group rpg ON rpg.population_group_id = rap.population_group_id
 LEFT OUTER JOIN ref_agency_covered_by racb ON racb.agency_id=rm.agency_id AND racb.data_year=rm.data_year
-LEFT OUTER JOIN ref_agency_covered_by_flat racbf ON racb.agency_id=rm.agency_id AND racb.data_year=rm.data_year
+LEFT OUTER JOIN ref_agency_covered_by_flat racbf ON racbf.agency_id=rm.agency_id AND racbf.data_year=rm.data_year
 LEFT OUTER JOIN reta_month covered_rm ON covered_rm.agency_id=racb.covered_by_agency_id AND covered_rm.data_year=rm.data_year AND covered_rm.month_num=rm.month_num
 LEFT OUTER JOIN nibrs_month covered_nm ON covered_nm.agency_id=racb.covered_by_agency_id AND covered_nm.data_year=nm.data_year AND covered_nm.month_num=nm.month_num
 GROUP BY rm.data_year, rs.state_name, rs.state_postal_abbr, ra.agency_id, ra.ori, ra.pub_agency_name, rap.population, rpg.population_group_code, rpg.population_group_desc, racb.covered_by_agency_id, racbf.covered_by_agency_id

--- a/tests/functional/test_authentication.py
+++ b/tests/functional/test_authentication.py
@@ -24,7 +24,7 @@ class TestAuthentication:
         monkeypatch.setenv('VCAP_APPLICATION', "foo")
         c.service_credentials.cache_clear()
 
-        res = testapp.get('/geo/states/WY', headers={'X-API-KEY': 'key'})
+        res = testapp.get('/geo/states/RI', headers={'X-API-KEY': 'key'})
         assert res.status_code == 200
 
     def test_query_login(self, monkeypatch, testapp):
@@ -41,7 +41,7 @@ class TestAuthentication:
         monkeypatch.setenv('VCAP_APPLICATION', "foo")
         c.service_credentials.cache_clear()
 
-        res = testapp.get('/geo/states/WY?api_key=key')
+        res = testapp.get('/geo/states/RI?api_key=key')
         assert res.status_code == 200
 
     def test_missing_login(self, monkeypatch, testapp):
@@ -58,9 +58,9 @@ class TestAuthentication:
         monkeypatch.setenv('VCAP_APPLICATION', "foo")
         c.service_credentials.cache_clear()
 
-        res = testapp.get('/geo/states/WY', expect_errors=True)
+        res = testapp.get('/geo/states/RI', expect_errors=True)
         assert res.status_code == 401
 
     def test_optional_login(self, testapp):
-        res = testapp.get('/geo/states/WY')
+        res = testapp.get('/geo/states/RI')
         assert res.status_code == 200

--- a/tests/unit/test_cdemodels.py
+++ b/tests/unit/test_cdemodels.py
@@ -47,20 +47,20 @@ class TestCdeRefCounty:
     def test_num_agencies(self, app):
         """Using the test data in the ref_agencies table"""
 
-        county = CdeRefCounty.get(county_id=2271).one()
-        assert county.total_agencies_for_year(1960) == 3
+        county = CdeRefCounty.get(county_id=2402).one()
+        assert county.total_agencies_for_year(2014) == 4
 
     def test_population(self, app):
         """Using the test data in the ref_county_population table"""
 
-        county = CdeRefCounty.get(county_id=74).one()
-        assert county.total_population_for_year(1960) == 24501
+        county = CdeRefCounty.get(county_id=2402).one()
+        assert county.total_population_for_year(2014) == 49251
 
     def test_police_officers(self, app):
         """Using the test data in the database"""
 
-        county = CdeRefCounty.get(county_id=3015).one()
-        assert county.police_officers_for_year(1977) == 19
+        county = CdeRefCounty.get(county_id=2402).one()
+        assert county.police_officers_for_year(2014) == 84
 
     def test_police_officers_missing_data(self, app):
 
@@ -90,32 +90,32 @@ class TestCdeRefState:
         assert s.state_name == 'California'
 
     def test_police_officers(self, app):
-        state = CdeRefState.get(abbr='VA').one()
-        assert state.police_officers_for_year(2008) == 48
+        state = CdeRefState.get(abbr='RI').one()
+        assert state.police_officers_for_year(2014) == 2497
 
     def test_participation(self, app):
-        test_year = 1960
-        state = CdeRefState.get(state_id=55).one()
+        test_year = 2014
+        state = CdeRefState.get(abbr='RI').one()
 
         # SELECT distinct rm.agency_id, ra.pub_agency_name
         # FROM reta_month rm
         # JOIN ref_agency ra ON ra.agency_id = rm.agency_id
-        # WHERE ra.state_id=55 and rm.data_year=1960
-        assert state.total_agencies_for_year(test_year) == 34
+        # WHERE ra.state_id=44 and rm.data_year=2014
+        assert state.total_agencies_for_year(test_year) == 56
 
         # SELECT distinct rm.agency_id, ra.pub_agency_name
         # FROM reta_month rm
         # JOIN ref_agency ra ON ra.agency_id = rm.agency_id
-        # WHERE ra.state_id=55 and rm.data_year=1960 AND
+        # WHERE ra.state_id=44 and rm.data_year=2014 AND
         # rm.reported_flag = 'Y'
-        assert state.reporting_agencies_for_year(test_year) == 13
-        assert state.reporting_rate_for_year(test_year) == pytest.approx(0.382352941)
+        assert state.reporting_agencies_for_year(test_year) == 52
+        assert state.reporting_rate_for_year(test_year) == pytest.approx(0.928571429)
 
         # select SUM(rac.population)
         # from ref_agency_county rac
         # JOIN ref_county rc ON rac.county_id = rc.county_id
-        # WHERE rc.state_id=55 and rac.data_year=1960;
-        assert state.total_population_for_year(test_year) == 706802
+        # WHERE rc.state_id=44 and rac.data_year=2014;
+        assert state.total_population_for_year(test_year) == 1061770
 
         # select SUM(rac.population)::text
         # from ref_agency_county rac
@@ -123,8 +123,8 @@ class TestCdeRefState:
         #                         JOIN ref_agency ra ON rm.agency_id=ra.agency_id
         #                         WHERE rm.reported_flag = 'Y'
         #                         AND rm.data_year=rac.data_year
-        #                         AND rm.data_year=1960 and ra.state_id=55)
-        assert state.covered_population_for_year(test_year) == 177770
+        #                         AND rm.data_year=2014 and ra.state_id=44)
+        assert state.covered_population_for_year(test_year) == 1055173
 
     def test_participation_cache_is_not_global(self, app):
         test_year = 1960

--- a/tests/unit/test_newmodels.py
+++ b/tests/unit/test_newmodels.py
@@ -9,19 +9,19 @@ import pytest
 class TestAgencyAnnualParticipation:
     def test_for_agency_in_nibrs_month(self, app):
         q = AgencyAnnualParticipation.query
-        q = q.filter(AgencyAnnualParticipation.data_year == 1991)
-        q = q.filter(AgencyAnnualParticipation.agency_id == 191).one()
+        q = q.filter(AgencyAnnualParticipation.data_year == 2014)
+        q = q.filter(AgencyAnnualParticipation.agency_id == 17381).one()
         assert q.reported == 1
-        assert q.months_reported == 2
+        assert q.months_reported == 12
         assert q.reported_nibrs == 1
-        assert q.months_reported_nibrs == 2
+        assert q.months_reported_nibrs == 12
 
     def test_for_agency_not_in_nibrs_month(self, app):
         q = AgencyAnnualParticipation.query
-        q = q.filter(AgencyAnnualParticipation.data_year == 2002)
-        q = q.filter(AgencyAnnualParticipation.agency_id == 9744).one()
+        q = q.filter(AgencyAnnualParticipation.data_year == 2014)
+        q = q.filter(AgencyAnnualParticipation.agency_id == 17427).one()
         assert q.reported == 1
-        assert q.months_reported == 3
+        assert q.months_reported == 12
         assert q.reported_nibrs == 0
         assert q.months_reported_nibrs == 0
 
@@ -29,32 +29,31 @@ class TestAgencyAnnualParticipation:
 class TestParticipationRate:
     def test_for_state_in_year(self, app):
         q = ParticipationRate.query
-        q = q.filter(ParticipationRate.data_year == 1999)
-        q = q.filter(ParticipationRate.state_id == 47).one()
-        assert q.data_year == 1999
-        assert q.state_id == 47
-        assert q.total_agencies == 8
-        assert q.reporting_agencies == 5
-        assert q.reporting_rate == pytest.approx(0.625)
-        assert q.nibrs_reporting_agencies == 3
-        assert q.nibrs_reporting_rate == pytest.approx(0.375)
+        q = q.filter(ParticipationRate.data_year == 2014)
+        q = q.filter(ParticipationRate.state_id == 44).one()
+        assert q.data_year == 2014
+        assert q.state_id == 44
+        assert q.total_agencies == 56
+        assert q.reporting_agencies == 52
+        assert q.reporting_rate == pytest.approx(0.928571429)
+        assert q.nibrs_reporting_agencies == 50
+        assert q.nibrs_reporting_rate == pytest.approx(0.892857143)
 
 
     def test_for_year(self, app):
         q = ParticipationRate.query
-        q = q.filter(ParticipationRate.data_year == 1991)
+        q = q.filter(ParticipationRate.data_year == 2014)
         q = q.filter(ParticipationRate.state_id == None)
         q = q.filter(ParticipationRate.county_id == None).one()
-
-        assert q.data_year == 1991
+        assert q.data_year == 2014
         assert q.state_id is None
-        assert q.total_agencies == 11
-        assert q.reporting_agencies == 2
-        assert q.reporting_rate == pytest.approx(0.181818182)
-        assert q.nibrs_reporting_agencies == 1
-        assert q.nibrs_reporting_rate == pytest.approx(0.090909091)
-        assert q.total_population == 83769
-        assert q.covered_population == 0
+        assert q.total_agencies == 58
+        assert q.reporting_agencies == 54
+        assert q.reporting_rate == pytest.approx(0.931034483)
+        assert q.nibrs_reporting_agencies == 50
+        assert q.nibrs_reporting_rate == pytest.approx(0.862068966)
+        assert q.total_population == 12142430
+        assert q.covered_population == 1323169
 
 
 class TestCdeAgencies:
@@ -112,9 +111,9 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = RetaMonthOffenseSubcatSummary.query
         q = q.filter(RetaMonthOffenseSubcatSummary.classification == 'Property')
         q = q.filter(RetaMonthOffenseSubcatSummary.offense == 'Arson')
-        q = q.filter(RetaMonthOffenseSubcatSummary.year == 1984)
+        q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == 1)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'VA')
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI')
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_subcat_code == None).one()
         assert q.reported == 7
         assert q.unfounded == 4
@@ -126,15 +125,15 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = RetaMonthOffenseSubcatSummary.query
         q = q.filter(RetaMonthOffenseSubcatSummary.classification == 'Property')
         q = q.filter(RetaMonthOffenseSubcatSummary.offense == 'Arson')
-        q = q.filter(RetaMonthOffenseSubcatSummary.year == 1984)
+        q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == None)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'VA')
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI')
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_subcat_code == None).one()
-        assert q.reported == 10
-        assert q.unfounded == 5
-        assert q.actual == 5
-        assert q.cleared == 0
-        assert q.juvenile_cleared == 0
+        assert q.reported == 254
+        assert q.unfounded == 0
+        assert q.actual == 254
+        assert q.cleared == 92
+        assert q.juvenile_cleared == 44
 
     def test_arson_fields_for_state(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -142,13 +141,13 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.offense == 'Arson')
         q = q.filter(RetaMonthOffenseSubcatSummary.month == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.year == None)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'VA')
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI')
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_subcat_code == None).one()
-        assert q.reported == 235
-        assert q.unfounded == 33
-        assert q.actual == 202
-        assert q.cleared == 32
-        assert q.juvenile_cleared == 12
+        assert q.reported == 254
+        assert q.unfounded == 0
+        assert q.actual == 254
+        assert q.cleared == 92
+        assert q.juvenile_cleared == 44
 
     def test_arson_fields_for_arson_total(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -158,25 +157,25 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.year == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.state == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_subcat_code == None).one()
-        assert q.reported == 4033
+        assert q.reported == 4287
         assert q.unfounded == 482
-        assert q.actual == 3551
-        assert q.cleared == 608
-        assert q.juvenile_cleared == 215
+        assert q.actual == 3805
+        assert q.cleared == 700
+        assert q.juvenile_cleared == 259
 
     def test_arson_fields_for_state_month_year(self, app):
         q = RetaMonthOffenseSubcatSummary.query
         q = q.filter(RetaMonthOffenseSubcatSummary.classification == 'Property')
         q = q.filter(RetaMonthOffenseSubcatSummary.offense == 'Arson')
-        q = q.filter(RetaMonthOffenseSubcatSummary.year == 1984)
+        q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == 1)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'VA')
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI')
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_subcat_code == None).one()
-        assert q.reported == 7
-        assert q.unfounded == 4
-        assert q.actual == 3
-        assert q.cleared == 0
-        assert q.juvenile_cleared == 0
+        assert q.reported == 10
+        assert q.unfounded == 0
+        assert q.actual == 10
+        assert q.cleared == 4
+        assert q.juvenile_cleared == 2
 
     # Test it is adding counts to Classification
     def test_classification_for_month_and_year_and_state(self, app):
@@ -186,12 +185,12 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_category == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == 1)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'AK').one()
-        assert q.reported == 12
-        assert q.unfounded == 1
-        assert q.actual == 11
-        assert q.cleared == 3
-        assert q.juvenile_cleared == 1
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI').one()
+        assert q.reported == 484
+        assert q.unfounded == 0
+        assert q.actual == 484
+        assert q.cleared == 47
+        assert q.juvenile_cleared == 8
 
     def test_classification_for_month_and_year(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -201,25 +200,11 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == 1)
         q = q.filter(RetaMonthOffenseSubcatSummary.state == None).one()
-        assert q.reported == 12
+        assert q.reported == 496
         assert q.unfounded == 1
-        assert q.actual == 11
-        assert q.cleared == 3
-        assert q.juvenile_cleared == 1
-
-    def test_classification_for_month_and_year_and_other_state(self, app):
-        q = RetaMonthOffenseSubcatSummary.query
-        q = q.filter(RetaMonthOffenseSubcatSummary.classification == 'Property')
-        q = q.filter(RetaMonthOffenseSubcatSummary.offense == None)
-        q = q.filter(RetaMonthOffenseSubcatSummary.offense_category == None)
-        q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014)
-        q = q.filter(RetaMonthOffenseSubcatSummary.month == 1)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'PA').one()
-        assert q.reported == 0
-        assert q.unfounded == 0
-        assert q.actual == 0
-        assert q.cleared == 0
-        assert q.juvenile_cleared == 0
+        assert q.actual == 495
+        assert q.cleared == 50
+        assert q.juvenile_cleared == 9
 
     def test_classification_for_month_and_state(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -228,12 +213,12 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_category == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == 1)
         q = q.filter(RetaMonthOffenseSubcatSummary.year == None)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'AK').one()
-        assert q.reported == 19
-        assert q.unfounded == 1
-        assert q.actual == 18
-        assert q.cleared == 4
-        assert q.juvenile_cleared == 1
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI').one()
+        assert q.reported == 484
+        assert q.unfounded == 0
+        assert q.actual == 484
+        assert q.cleared == 47
+        assert q.juvenile_cleared == 8
 
     def test_classification_for_year_and_state(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -242,12 +227,12 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_category == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'AK').one()
-        assert q.reported == 12
-        assert q.unfounded == 1
-        assert q.actual == 11
-        assert q.cleared == 3
-        assert q.juvenile_cleared == 1
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI').one()
+        assert q.reported == 5913
+        assert q.unfounded == 0
+        assert q.actual == 5913
+        assert q.cleared == 757
+        assert q.juvenile_cleared == 135
 
     def test_classification_for_state(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -256,12 +241,12 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_category == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.month == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.year == None)
-        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'AK').one()
-        assert q.reported == 27
-        assert q.unfounded == 4
-        assert q.actual == 23
-        assert q.cleared == 7
-        assert q.juvenile_cleared == 2
+        q = q.filter(RetaMonthOffenseSubcatSummary.state == 'RI').one()
+        assert q.reported == 5913
+        assert q.unfounded == 0
+        assert q.actual == 5913
+        assert q.cleared == 757
+        assert q.juvenile_cleared == 135
 
     def test_classification_for_year(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -271,11 +256,11 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.month == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.state == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.year == 2014).one()
-        assert q.reported == 12
+        assert q.reported == 5925
         assert q.unfounded == 1
-        assert q.actual == 11
-        assert q.cleared == 3
-        assert q.juvenile_cleared == 1
+        assert q.actual == 5924
+        assert q.cleared == 760
+        assert q.juvenile_cleared == 136
 
     def test_classification_overall(self, app):
         q = RetaMonthOffenseSubcatSummary.query
@@ -285,8 +270,8 @@ class TestArsonAdditionsToRetaMonthOffenseSubcatSummary:
         q = q.filter(RetaMonthOffenseSubcatSummary.year == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.state == None)
         q = q.filter(RetaMonthOffenseSubcatSummary.offense_category == None).one()
-        assert q.reported == 4112
+        assert q.reported == 10025
         assert q.unfounded == 482
-        assert q.actual == 3630
-        assert q.cleared == 610
-        assert q.juvenile_cleared == 215
+        assert q.actual == 9543
+        assert q.cleared == 1367
+        assert q.juvenile_cleared == 350


### PR DESCRIPTION
Because we will need to have 12-month participation, the sample data was too incomplete for some tests. So I have added records from 2014 in Rhode Island to the following tables:

* reta_month
* ref_agency
* ref_agency_county
* reta_offense
* reta_offense_subcat
* reta_month_offense_subcat
* arson_month
* arson_month_by_subcat
* arson_subcat
* pe_employee_data

So, get yourself a nice coffee milk and enjoy the world of 2014 Rhode Island crime