### PR TITLE
Add a .cfignore to the project

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,54 @@
+dba/crime_data_api_test.sql
+
+tests/
+
+*.py[cod]
+
+# Packages
+*.egg
+*.egg-info
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build
+
+.webassets-cache
+
+.cache/
+
+# Virtualenvs
+env/
+venv/
+
+.cache/
+prospector.log
+*.swp


### PR DESCRIPTION
I just realized we never had a .cfignore for this project which means that all sorts of files are being deployed that don't need to be pushed to the server like the test DB SQL or the tests directory