### PR TITLE
One more fix for RETA agency api.

### DIFF
--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -263,7 +263,7 @@ class AgencySums(db.Model):
                 )
             if year:
                 subq = subq.filter(models.RefAgencyCounty.data_year == year)
-                query = query.filter(AgencySums.agency_id.in_(subq))
+            query = query.filter(AgencySums.agency_id.in_(subq))
         if agency:
             query = query.filter(AgencySums.agency_ori == agency)
         if year:
@@ -274,6 +274,7 @@ class AgencySums(db.Model):
         query = query.filter(AgencySums.reported == 12 ) # Agency reported 12 Months.
         #print(query) # Dubug
         return query
+
 
 class RetaMonthOffenseSubcatSummary(db.Model, CreatableModel):
     """


### PR DESCRIPTION
Well this is embarrassing.  - I left one tab too many. The query for counties doesn't execute the subquery for the county info if no year is supplied. 