### PR TITLE
Added CSV output ability. Fixed ORI only requests.

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -137,6 +137,9 @@ def add_resources(app):
     api.add_resource(crime_data.resources.incidents.CachedIncidentsAgenciesCount,
                      '/agencies/count/states/offenses/<string:state_abbr>/<string:agency_ori>','/agencies/count/states/offenses/<string:state_abbr>' )
 
+    api.add_resource(crime_data.resources.incidents.CachedIncidentsAgenciesCountyCount,
+                     '/agencies/count/states/offenses/<string:state_abbr>/counties/<string:county_fips_code>' )
+
     # api.add_resource(crime_data.resources.incidents.IncidentsDetail,
     #                  '/incidents/<int:id>/')
     api.add_resource(crime_data.resources.offenses.OffensesList, '/offenses/')

--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -130,6 +130,7 @@ def add_resources(app):
                      '/counts')
     api.add_resource(crime_data.resources.incidents.AgenciesSumsState,
                      '/agencies/count/states/suboffenses/<string:state_abbr>/<string:agency_ori>','/agencies/count/states/suboffenses/<string:state_abbr>' )
+
     api.add_resource(crime_data.resources.incidents.AgenciesSumsCounty,
                      '/agencies/count/states/suboffenses/<string:state_abbr>/counties/<string:county_fips_code>' )
 

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -210,7 +210,7 @@ class RetaMonthAgencySubcatSummary(db.Model):
     rape_cleared = db.Column(db.BigInteger)
     rape_juvenile_cleared = db.Column(db.BigInteger)
 
-    def get(self, state = None, agency = None, year = None):
+    def get(self, state = None, agency = None, year = None, county = None):
         """Get Agency - Offense counts given some filters."""
         query = RetaMonthAgencySubcatSummary.query
 

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -259,19 +259,18 @@ class AgencySums(db.Model):
                     .select_from(models.RefAgencyCounty)
                     .join(models.RefCounty, and_(models.RefAgencyCounty.county_id == models.RefCounty.county_id))
                     .filter(models.RefCounty.county_fips_code == county)
-                    .subquery()
                 )
             if year:
                 subq = subq.filter(models.RefAgencyCounty.data_year == year)
-            query = query.filter(AgencySums.agency_id.in_(subq))
+            query = query.filter(AgencySums.agency_id.in_(subq.subquery()))
         if agency:
-            query = query.filter(AgencySums.agency_ori == agency)
+            query = query.filter(AgencySums.ori == agency)
         if year:
             query = query.filter(AgencySums.year == year)
 
         # Heads up - This is going to probably make local tests fail, as our sample DB's 
         # only contain a little bit of data - ie. reported may not be 12 (ever).
-        query = query.filter(AgencySums.reported == 12 ) # Agency reported 12 Months.
+        query = query.filter(AgencySums.reported == 12 ).order_by(AgencySums.year.desc()) # Agency reported 12 Months.
         #print(query) # Dubug
         return query
 

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -217,7 +217,7 @@ class RetaMonthAgencySubcatSummary(db.Model):
         if state:
             query = query.filter(func.lower(RetaMonthAgencySubcatSummary.state_postal_abbr) == state.lower())
         if county:
-            subq = (db.session.query(models.RetaMonthAgencySubcatSummary.agency_id)
+            subq = (db.session.query(RetaMonthAgencySubcatSummary.agency_id)
                     .select_from(models.RefAgencyCounty)
                     .join(models.RefCounty, and_(models.RefAgencyCounty.county_id == models.RefCounty.county_id))
                     .filter(models.RefCounty.county_fips_code == county)

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -216,6 +216,15 @@ class RetaMonthAgencySubcatSummary(db.Model):
 
         if state:
             query = query.filter(func.lower(RetaMonthAgencySubcatSummary.state_postal_abbr) == state.lower())
+        if county:
+            subq = (db.session.query(models.RetaMonthAgencySubcatSummary.agency_id)
+                    .select_from(models.RefAgencyCounty)
+                    .join(models.RefCounty, and_(models.RefAgencyCounty.county_id == models.RefCounty.county_id))
+                    .filter(models.RefCounty.county_fips_code == county)
+                )
+            if year:
+                subq = subq.filter(models.RefAgencyCounty.data_year == year)
+            query = query.filter(RetaMonthAgencySubcatSummary.agency_id.in_(subq.subquery()))
         if agency:
             query = query.filter(RetaMonthAgencySubcatSummary.agency_ori == agency)
         if year:

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -99,7 +99,8 @@ class AgenciesSumsState(CdeResource):
         if 'year' in args:
             year = args['year']
         agency_sums = model.get(state = state_abbr, agency = agency_ori, year = year)
-        return self.with_metadata(self.schema.dump(agency_sums).data, args)
+        filename = 'agency_sums_state'
+        return self.render_response(self.schema.dump(agency_sums).data, args, csv_filename=filename)
 
 
 class AgenciesSumsCounty(CdeResource):
@@ -120,7 +121,8 @@ class AgenciesSumsCounty(CdeResource):
         if 'year' in args:
             year = args['year']
         agency_sums = model.get(agency = agency_ori, year =  year, county = county_fips_code, state=state_abbr)
-        return self.with_metadata(self.schema.dump(agency_sums).data, args)
+        filename = 'agency_sums_county'
+        return self.render_response(self.schema.dump(agency_sums).data, args, csv_filename=filename)
 
 
 class CachedIncidentsAgenciesCount(CdeResource):
@@ -138,4 +140,5 @@ class CachedIncidentsAgenciesCount(CdeResource):
         if 'year' in args:
             year = args['year']
         reta_offenses = model.get(state = state_abbr, agency = agency_ori, year = year)
-        return self.with_metadata(self.schema.dump(reta_offenses).data, args)
+        filename = 'agency_sums'
+        return self.render_response(self.schema.dump(reta_offenses).data, args, csv_filename=filename)

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -142,3 +142,21 @@ class CachedIncidentsAgenciesCount(CdeResource):
         reta_offenses = model.get(state = state_abbr, agency = agency_ori, year = year)
         filename = 'agency_sums'
         return self.render_response(self.schema.dump(reta_offenses).data, args, csv_filename=filename)
+
+class CachedIncidentsAgenciesCountyCount(CdeResource):
+    '''''
+    Agency Offense counts by year.
+    '''''
+    schema = marshmallow_schemas.CachedAgencyIncidentCountSchema(many=True)
+
+    @use_args(marshmallow_schemas.OffenseCountViewArgs)
+    @tuning_page
+    def get(self, args, state_abbr = None, agency_ori = None, county_fips_code = None):
+        self.verify_api_key(args)
+        model = newmodels.RetaMonthAgencySubcatSummary()
+        year = None
+        if 'year' in args:
+            year = args['year']
+        reta_offenses = model.get(state = state_abbr, agency = agency_ori, year = year, county = county_fips_code)
+        filename = 'agency_sums'
+        return self.render_response(self.schema.dump(reta_offenses).data, args, csv_filename=filename)

--- a/crime_data/static/swagger.json
+++ b/crime_data/static/swagger.json
@@ -2999,11 +2999,176 @@
         }
       }
     },
+    "/agencies/count/states/suboffenses/{state_abbr}/{agency_ori}": {
+      "get": {
+        "tags": [
+          "suboffenses",
+          "states",
+          "agencies"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/hateCrimesCountVariableParam"
+          },
+          {
+            "$ref": "#/parameters/aggregateManyParam"
+          },
+          {
+            "$ref": "#/parameters/fieldsParam"
+          },
+          {
+            "$ref": "#/parameters/pageParam"
+          },
+          {
+            "$ref": "#/parameters/perPageParam"
+          },
+          {
+            "$ref": "#/parameters/outputParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "required": [
+                "pagination",
+                "results"
+              ],
+              "properties": {
+                "pagination": {
+                  "$ref": "#/definitions/Pagination"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/RetaAgencyCount"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/Error"
+          }
+        }
+      }
+    },
     "/agencies/count/states/offenses/{state_abbr}": {
       "get": {
         "tags": [
           "offenses",
           "states"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/hateCrimesCountVariableParam"
+          },
+          {
+            "$ref": "#/parameters/aggregateManyParam"
+          },
+          {
+            "$ref": "#/parameters/fieldsParam"
+          },
+          {
+            "$ref": "#/parameters/pageParam"
+          },
+          {
+            "$ref": "#/parameters/perPageParam"
+          },
+          {
+            "$ref": "#/parameters/outputParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "required": [
+                "pagination",
+                "results"
+              ],
+              "properties": {
+                "pagination": {
+                  "$ref": "#/definitions/Pagination"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/RetaAgencyCountOffense"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/Error"
+          }
+        }
+      }
+    },
+    "/agencies/count/states/offenses/{state_abbr}/counties/{county_fips_code}": {
+      "get": {
+        "tags": [
+          "offenses",
+          "states",
+          "counties"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/hateCrimesCountVariableParam"
+          },
+          {
+            "$ref": "#/parameters/aggregateManyParam"
+          },
+          {
+            "$ref": "#/parameters/fieldsParam"
+          },
+          {
+            "$ref": "#/parameters/pageParam"
+          },
+          {
+            "$ref": "#/parameters/perPageParam"
+          },
+          {
+            "$ref": "#/parameters/outputParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "required": [
+                "pagination",
+                "results"
+              ],
+              "properties": {
+                "pagination": {
+                  "$ref": "#/definitions/Pagination"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/RetaAgencyCountOffense"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/Error"
+          }
+        }
+      }
+    },
+    "/agencies/count/states/offenses/{state_abbr}/{agency_ori}": {
+      "get": {
+        "tags": [
+          "offenses",
+          "states",
+          "agencies"
         ],
         "parameters": [
           {


### PR DESCRIPTION
This PR adds CSV output ability on the agency level sums endpoints. Also fixes issue with ORI specific requests.  
Added API's for getting offense level counts by ORI, and county fips.
