### PR TITLE
Reta agency API

### DIFF
--- a/crime_data/common/marshmallow_schemas.py
+++ b/crime_data/common/marshmallow_schemas.py
@@ -217,8 +217,6 @@ class AgencySumsSchema(Schema):
     agency_id = marsh_fields.Integer()
     ori = marsh_fields.String()
     state_postal_abbr = marsh_fields.String()
-    ucr_agency_name = marsh_fields.String()
-    ncic_agency_name = marsh_fields.String()
     pub_agency_name = marsh_fields.String()
     offense_id = marsh_fields.Integer()
     offense_code = marsh_fields.String() # reta_offense

--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -241,10 +241,9 @@ class AgencySums(db.Model):
     agency_id = db.Column(db.BigInteger)
     state_postal_abbr = db.Column(db.Text)
     ori = db.Column(db.Text)
-    ucr_agency_name = db.Column(db.Text)
-    ncic_agency_name = db.Column(db.Text)
     pub_agency_name = db.Column(db.Text)
     offense_id = db.Column(db.BigInteger) # reta_offense_subcat
+    offense_subcat_id = db.Column(db.BigInteger)
     offense_code = db.Column(db.Text) # reta_offense
     offense_subcat_code = db.Column(db.Text)
     offense_subcat_name = db.Column(db.Text)
@@ -254,9 +253,6 @@ class AgencySums(db.Model):
     actual = db.Column(db.BigInteger)
     cleared = db.Column(db.BigInteger)
     juvenile_cleared = db.Column(db.BigInteger)
-    ucr_agency_name = db.Column(db.String(100))
-    ncic_agency_name = db.Column(db.String(100))
-    pub_agency_name = db.Column(db.String(100))
 
     def get(self, state = None, agency = None, year = None, county = None):
         """Get Agency Sums given a state/year/county/agency ori, etc."""

--- a/dba/after_load/create_reta_agency_summary.sql
+++ b/dba/after_load/create_reta_agency_summary.sql
@@ -18,8 +18,7 @@ CREATE TABLE agency_sums (
  id SERIAL PRIMARY KEY,
  data_year smallint NOT NULL,
  agency_id bigint NOT NULL, 
- offense_id bigint NOT NULL,
- offense_code varchar(20),
+ offense_subcat_id bigint NOT NULL,
  reported integer, 
  unfounded integer,
  actual integer,
@@ -37,10 +36,10 @@ BEGIN
    LOOP
     RAISE NOTICE 'Executing Inserts for offense_subcat_id: %', i;
     SET work_mem='3GB';
-    INSERT INTO agency_sums (data_year, agency_id, offense_id, reported, unfounded, actual, cleared, juvenile_cleared)  
+    INSERT INTO agency_sums (data_year, agency_id, offense_subcat_id, reported, unfounded, actual, cleared, juvenile_cleared)  
     SELECT rm.data_year,
     rm.agency_id,
-    ros.offense_id,
+    ros.offense_subcat_id,
     SUM(rmos.reported_count) AS reported,
     SUM(rmos.unfounded_count) AS unfounded,
     SUM(rmos.actual_count) AS actual,
@@ -51,7 +50,7 @@ BEGIN
     JOIN reta_month rm ON (rmos.reta_month_id = rm.reta_month_id)
     JOIN agency_reporting ar ON ar.agency_id=rm.agency_id AND ar.data_year=rm.data_year
     WHERE ar.reported IS TRUE
-    GROUP BY rm.data_year, rm.agency_id, ros.offense_id;
+    GROUP BY rm.data_year, rm.agency_id, ros.offense_subcat_id;
    END LOOP;
 END
 $do$;
@@ -84,6 +83,7 @@ create TABLE agency_sums_view (
  year smallint NOT NULL,
  agency_id bigint NOT NULL, 
  offense_id bigint NOT NULL,
+ offense_subcat_id bigint NOT NULL,
  offense_code varchar(20),
  offense_name text,
  reported integer, 
@@ -106,12 +106,14 @@ BEFORE INSERT ON agency_sums_view
 FOR EACH ROW EXECUTE PROCEDURE create_state_partition_and_insert();
 
 SET work_mem='3GB';
-INSERT INTO agency_sums_view (id, year, agency_id, offense_id, offense_code, offense_name, reported, unfounded, actual, cleared, juvenile_cleared,ori,ucr_agency_name,ncic_agency_name,pub_agency_name,offense_subcat_name,offense_subcat_code,state_postal_abbr)
+SET synchronous_commit TO OFF;
+INSERT INTO agency_sums_view   (id, year, agency_id, offense_subcat_id, offense_id, offense_code, offense_name, reported, unfounded, actual, cleared, juvenile_cleared,ori,pub_agency_name,offense_subcat_name,offense_subcat_code,state_postal_abbr)
   SELECT 
     asums.id,
     asums.data_year as year,
     asums.agency_id,
-    asums.offense_id,
+    asums.offense_subcat_id,
+    ro.offense_id,
     ro.offense_code,
     ro.offense_name,
     asums.reported,
@@ -120,16 +122,14 @@ INSERT INTO agency_sums_view (id, year, agency_id, offense_id, offense_code, off
     asums.cleared,
     asums.juvenile_cleared,
     ag.ori,
-    ag.ucr_agency_name,
-    ag.ncic_agency_name,
     ag.pub_agency_name,
     ros.offense_subcat_name,
     ros.offense_subcat_code,
     rs.state_postal_abbr
   from agency_sums asums 
   JOIN ref_agency ag ON (asums.agency_id = ag.agency_id)
-  JOIN reta_offense_subcat ros ON (asums.offense_id = ros.offense_subcat_id)
-  JOIN reta_offense ro ON asums.offense_id=ro.offense_id
+  JOIN reta_offense_subcat ros ON (asums.offense_subcat_id = ros.offense_subcat_id)
+  JOIN reta_offense ro ON ros.offense_id=ro.offense_id
   JOIN ref_state rs ON (rs.state_id  = ag.state_id);
 
 
@@ -137,8 +137,7 @@ DROP SEQUENCE IF EXISTS retacubeseq CASCADE;
 CREATE SEQUENCE retacubeseq;
 
 DROP TABLE IF EXISTS reta_agency_offense_summary;
-CREATE TABLE reta_agency_offense_summary AS
-SELECT
+CREATE TABLE reta_agency_offense_summary AS SELECT 
 NEXTVAL('retacubeseq') AS reta_agency_summary_id,
 ar.data_year AS year,
 rs.state_postal_abbr,
@@ -160,12 +159,71 @@ rape.reported AS rape_reported,
 rape.actual AS rape_actual,
 rape.cleared AS rape_cleared,
 rape.juvenile_cleared AS rape_juvenile_cleared
-FROM agency_reporting ar
+FROM   agency_reporting ar
 JOIN ref_agency ra ON ra.agency_id=ar.agency_id
 LEFT OUTER JOIN ref_state rs ON rs.state_id=ra.state_id
 LEFT OUTER JOIN ref_agency_covered_by racb ON racb.agency_id=ar.agency_id AND racb.data_year=ar.data_year
 LEFT OUTER JOIN covering_counts cvring ON cvring.covered_by_agency_id=ar.agency_id AND cvring.data_year=ar.data_year
 LEFT OUTER JOIN ref_agency_population rap ON rap.agency_id=ar.agency_id AND rap.data_year=ar.data_year
 LEFT OUTER JOIN ref_population_group rpg ON rpg.population_group_id=rap.population_group_id
-LEFT OUTER JOIN agency_sums homicide ON homicide.agency_id=ar.agency_id AND homicide.data_year=ar.data_year AND homicide.offense_code='SUM_HOM'
-LEFT OUTER JOIN agency_sums rape ON rape.agency_id=ar.agency_id AND rape.data_year=ar.data_year AND rape.offense_code='SUM_RPE';
+LEFT JOIN (
+    SELECT 
+      year,
+      agency_id,
+      sum(agency_sums_view.reported) AS reported,
+      sum(agency_sums_view.actual) AS actual,
+      sum(agency_sums_view.cleared) AS cleared,
+      sum(agency_sums_view.juvenile_cleared) AS juvenile_cleared 
+      FROM  agency_sums_view
+      WHERE offense_code = 'SUM_HOM'
+      GROUP  BY (year, agency_id)
+    ) homicide ON homicide.agency_id=ar.agency_id AND homicide.year=ar.data_year 
+LEFT JOIN (
+    SELECT 
+      year,
+      agency_id,
+      sum(agency_sums_view.reported) AS reported,
+      sum(agency_sums_view.actual) AS actual,
+      sum(agency_sums_view.cleared) AS cleared,
+      sum(agency_sums_view.juvenile_cleared) AS juvenile_cleared 
+      FROM  agency_sums_view
+      WHERE offense_code = 'SUM_RPE'
+      GROUP BY (year, agency_id)
+    ) rape ON rape.agency_id=ar.agency_id AND rape.year=ar.data_year;
+
+
+CREATE UNIQUE INDEX reta_offense_agency_year_idx ON  reta_agency_offense_summary (year, agency_id);
+
+-- DROP TABLE IF EXISTS reta_agency_offense_summary;
+-- CREATE TABLE reta_agency_offense_summary AS
+-- SELECT
+-- NEXTVAL('retacubeseq') AS reta_agency_summary_id,
+-- ar.data_year AS year,
+-- rs.state_postal_abbr,
+-- rs.state_name,
+-- ra.agency_id,
+-- ra.ori AS agency_ori,
+-- ra.pub_agency_name AS agency_name,
+-- ar.reported AS reported,
+-- CASE WHEN racb.agency_id IS NOT NULL THEN TRUE ELSE FALSE END AS covered,
+-- cvring.count AS covering_count,
+-- rap.population AS agency_population,
+-- rpg.population_group_code AS population_group_code,
+-- rpg.population_group_desc AS population_group,
+-- sum(homicide.reported) AS homicide_reported,
+-- sum(homicide.actual) AS homicide_actual,
+-- sum(homicide.cleared) AS homicide_cleared,
+-- sum(homicide.juvenile_cleared) AS homicide_juvenile_cleared,
+-- sum(rape.reported) AS rape_reported,
+-- sum(rape.actual) AS rape_actual,
+-- sum(rape.cleared) AS rape_cleared,
+-- sum(rape.juvenile_cleared) AS rape_juvenile_cleared
+-- FROM agency_reporting ar
+-- JOIN ref_agency ra ON ra.agency_id=ar.agency_id
+-- LEFT OUTER JOIN ref_state rs ON rs.state_id=ra.state_id
+-- LEFT OUTER JOIN ref_agency_covered_by racb ON racb.agency_id=ar.agency_id AND racb.data_year=ar.data_year
+-- LEFT OUTER JOIN covering_counts cvring ON cvring.covered_by_agency_id=ar.agency_id AND cvring.data_year=ar.data_year
+-- LEFT OUTER JOIN ref_agency_population rap ON rap.agency_id=ar.agency_id AND rap.data_year=ar.data_year
+-- LEFT OUTER JOIN ref_population_group rpg ON rpg.population_group_id=rap.population_group_id
+-- LEFT OUTER JOIN agency_sums_view homicide ON homicide.agency_id=ar.agency_id AND homicide.data_year=ar.data_year AND homicide.offense_code='SUM_HOM'
+-- LEFT OUTER JOIN agency_sums_view rape ON rape.agency_id=ar.agency_id AND rape.data_year=ar.data_year AND rape.offense_code='SUM_RPE';

--- a/update.sh
+++ b/update.sh
@@ -1,1 +1,1 @@
-curl https://s3.amazonaws.com/18f-cf-cli/psql-9.4.4-ubuntu-14.04.tar.gz | tar xvz && ./psql/bin/psql $DATABASE_URL -f sql/update.sql && echo SUCCESS || echo FAIL
+curl https://s3.amazonaws.com/18f-cf-cli/psql-9.4.4-ubuntu-14.04.tar.gz | tar xvz && ./psql/bin/psql $DATABASE_URL -f dba/after_load/update.sql && echo SUCCESS || echo FAIL


### PR DESCRIPTION
Okay 
- So this might be a good middle ground. I reworked the offense count table to group/sum the results.
- I also fixed the agency_sums to correctly sum up the sub offense counts.

One thing I don't like: Sub-offense counts return an object for each (sub-offense, agency, year) which means that pagination could cut off parts of the response. This shouldn't be an issue when requesting one agency at a time. But ideally we would return the full payload in one object. ie.
[
  {
     ori:
     year:
     suboffense_count1:
     suboffense_count2:
     suboffense_countN:
  }, ...
]


buuuut. It's actually a pretty tough thing to tackle - I'd rather wait to see if it's worth doing before going down this road.
  