### PR TITLE
Use reta_month to get current_year for cde_agencies

### DIFF
--- a/dba/after_load/denorm-agencies.sql
+++ b/dba/after_load/denorm-agencies.sql
@@ -61,7 +61,7 @@ SELECT
 ra.agency_id,
 ra.ori,
 ra.legacy_ori,
-ra.pub_agency_name || CASE WHEN ra.agency_type_id = 2 THEN ' County' ELSE '' END AS agency_name,
+ra.pub_agency_name || CASE WHEN ra.agency_type_id = 2 AND ra.pub_agency_name NOT LIKE '%County%' THEN ' County' ELSE '' END AS agency_name,
 ra.agency_type_id,
 rat.agency_type_name,
 ra.tribe_id,
@@ -86,7 +86,7 @@ rap.source_flag AS population_source_flag,
 rap.suburban_area_flag,
 rac.core_city_flag,
 cap.months_reported,
-cap.nibrs_reported AS nibrs_months_reported,
+cap.nibrs_months_reported AS nibrs_months_reported,
 racp.covered_by_agency_id AS covered_by_id,
 covering.ori AS covered_by_ori,
 covering.pub_agency_name AS covered_by_name,
@@ -95,7 +95,7 @@ COALESCE(ped.male_officer + ped.female_officer) AS total_officers,
 COALESCE(ped.male_civilian + ped.female_civilian) AS total_civilians
 FROM ref_agency ra
 JOIN ref_agency_type rat ON rat.agency_type_id = ra.agency_type_id
-LEFT OUTER JOIN (SELECT agency_id, min(data_year) AS start_year, max(data_year) AS current_year FROM ref_agency_population GROUP BY agency_id) y ON y.agency_id=ra.agency_id
+LEFT OUTER JOIN (SELECT agency_id, min(data_year) AS start_year, max(data_year) AS current_year FROM reta_month GROUP BY agency_id) y ON y.agency_id=ra.agency_id
 LEFT OUTER JOIN (SELECT agency_id, max(data_year) AS staffing_year FROM pe_employee_data WHERE reported_flag='Y' GROUP BY agency_id) pe ON pe.agency_id=ra.agency_id
 LEFT OUTER JOIN (SELECT agency_id, min(data_year) AS revised_year FROM ref_agency_data_content WHERE summary_rape_def = 'R' GROUP BY agency_id) radc ON radc.agency_id=ra.agency_id
 LEFT OUTER JOIN ref_city rc ON rc.city_id=ra.city_id

--- a/tests/unit/test_newmodels.py
+++ b/tests/unit/test_newmodels.py
@@ -110,19 +110,25 @@ class TestCdeAgencies:
         assert a.dormant_year == 1983
 
     def test_agency_covering(self, app):
-        a = CdeAgency.query.filter(CdeAgency.agency_id == 16487).one()
+        a = CdeAgency.query.filter(CdeAgency.agency_id == 17398).one()
         assert a is not None
-        assert a.current_year == 1984
-        assert a.covered_by_id == 16495
-        assert a.covered_by_ori == 'PA030SP00'
-        assert a.covered_by_name == 'State Police: Greene County'
+        assert a.current_year == 2014
+        assert a.covered_by_id == 17439
+        assert a.covered_by_ori == 'RIRSP0500'
+        assert a.covered_by_name == 'State Police: Lincoln'
+        assert a.months_reported == 0
+        assert a.nibrs_months_reported == 0
 
     def test_current_year_and_population(self, app):
-        a = CdeAgency.query.filter(CdeAgency.agency_id == 15909).one()
+        a = CdeAgency.query.filter(CdeAgency.agency_id == 17385).one()
         assert a is not None
-        assert a.current_year == 2013
-        assert a.population == 10479
+        assert a.current_year == 2014
+        assert a.population == 35053
         assert a.suburban_area_flag == 'Y'
+        assert a.population_group_code == '4'
+        assert a.population_group_desc == 'Cities from 25,000 thru 49,999'
+        assert a.months_reported == 12
+        assert a.nibrs_months_reported == 12
 
     def test_city_association(self, app):
         a = CdeAgency.query.filter(CdeAgency.agency_id == 12223).one()
@@ -140,7 +146,7 @@ class TestCdeAgencies:
         assert a.total_civilians == 169
 
     def test_core_city_flag(self, app):
-        a = CdeAgency.query.filter(CdeAgency.agency_id == 1484).one()
+        a = CdeAgency.query.filter(CdeAgency.agency_id == 17407).one()
         assert a is not None
         assert a.core_city_flag == 'Y'
 


### PR DESCRIPTION
Fixes #501. This is already fixed in production, but this PR updates the test data and tests...