### PR TITLE
Widen NIBRS rape mapping

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -483,7 +483,7 @@ class ExplorerOffenseMapping(object):
                     'Theft From Coin-Operated Machine or Device'],
         'motor-vehicle-theft': 'Motor Vehicle Theft',
         'homicide': 'Murder and Nonnegligent Manslaughter',
-        'rape': 'Rape',
+        'rape': ['Rape', 'Sexual Assault With An Object', 'Incest'],
         'robbery': 'Robbery',
         'arson': 'Arson'
     }


### PR DESCRIPTION
Fixes https://github.com/18F/crime-data-explorer/issues/129

It was suggested on a recent call that our page for rape should also map to the NIBRS offenses of Incest and Sexual Assault With An Object, so... 

(this database will make you sad sometimes)