### PR TITLE
Reworked queries to perform a lot better.

### DIFF
--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -94,4 +94,5 @@ class OffenseByOffenseTypeSubcounts(CdeResource):
                                                         state_id=state_id,
                                                         state_abbr=state_abbr)
         results = model.query(args)
+        print(results)
         return self.with_metadata(results.fetchall(), args)

--- a/dba/after_load/mat-views/cargo-theft.sql
+++ b/dba/after_load/mat-views/cargo-theft.sql
@@ -84,5 +84,8 @@ GROUP BY GROUPING SETS (
     (year, ori, offense_name, victim_type_name)
 );
 
-CREATE INDEX ct_counts_state_id_idx ON ct_counts (state_id);
-CREATE INDEX offense_ct_counts_state_id_idx ON offense_ct_counts (state_id);
+CREATE INDEX ct_counts_state_id_idx ON ct_counts (state_id, year);
+CREATE INDEX offense_ct_counts_state_id_idx ON offense_ct_counts (state_id, year);
+
+CREATE INDEX ct_counts_ori_idx ON ct_counts (ori, year);
+CREATE INDEX offense_ct_counts_ori_idx ON offense_ct_counts (ori, year);

--- a/dba/after_load/mat-views/hate-crime.sql
+++ b/dba/after_load/mat-views/hate-crime.sql
@@ -30,3 +30,8 @@ GROUP BY GROUPING SETS (
     (year, state_id, offense_name, bias_name),
     (year, ori, offense_name, bias_name)
 );
+
+CREATE INDEX hc_counts_state_id_year_idx ON hc_counts (state_id, year);
+CREATE INDEX offense_hc_counts_state_id_year_idx ON offense_hc_counts (state_id, year);
+CREATE INDEX hc_counts_ori_year_idx ON hc_counts (ori, year);
+CREATE INDEX offense_hc_counts_ori_year_idx ON offense_hc_counts (ori, year);

--- a/dba/after_load/mat-views/offender-offenses.sql
+++ b/dba/after_load/mat-views/offender-offenses.sql
@@ -82,5 +82,7 @@ create materialized view offense_offender_counts as
     SELECT *,1992 as year FROM offense_offender_counts_1992 UNION
     SELECT *,1991 as year FROM offense_offender_counts_1991;
 
-CREATE INDEX offense_offender_counts_state_id_idx ON offense_offender_counts (state_id);
+CREATE INDEX offense_offender_counts_state_id_idx ON offense_offender_counts (state_id, year, offense_name);
+CREATE INDEX offense_counts_ori_idx ON offense_counts (ori, year, offense_name);
+
 

--- a/dba/after_load/mat-views/offender.sql
+++ b/dba/after_load/mat-views/offender.sql
@@ -72,4 +72,5 @@ create materialized view offender_counts as
     SELECT *, 1992 as year FROM offender_counts_1992 UNION
     SELECT *, 1991 as year FROM offender_counts_1991;
 
-CREATE INDEX offender_counts_state_id_idx ON offender_counts (state_id);
+CREATE INDEX offender_counts_state_year_id_idx ON offender_counts (state_id, year);
+CREATE INDEX offender_counts_ori_year_idx ON offender_counts (ori, year);

--- a/dba/after_load/mat-views/offense-offenses.sql
+++ b/dba/after_load/mat-views/offense-offenses.sql
@@ -61,4 +61,5 @@ create materialized view offense_offense_counts as
     SELECT *,1992 as year  FROM offense_offense_counts_1992 UNION
     SELECT *,1991 as year  FROM offense_offense_counts_1991;
 
-CREATE INDEX offense_offense_counts_state_id_idx ON offense_counts (state_id);
+CREATE INDEX offense_offense_counts_state_id_idx ON offense_counts (state_id, year, offense_name);
+CREATE INDEX offense_offense_counts_ori_idx ON offense_counts (ori, year, offense_name);

--- a/dba/after_load/mat-views/offense.sql
+++ b/dba/after_load/mat-views/offense.sql
@@ -64,4 +64,5 @@ create materialized view offense_counts as
     SELECT *,1992 as year  FROM offense_counts_1992 UNION
     SELECT *,1991 as year  FROM offense_counts_1991;
 
-CREATE INDEX offense_counts_state_id_idx ON offense_counts (state_id);
+CREATE INDEX offense_counts_state_year_id_idx ON offense_counts (state_id, year);
+CREATE INDEX offense_counts_ori_year_idx ON offense_counts (ori, year);

--- a/dba/after_load/mat-views/victim-offenses.sql
+++ b/dba/after_load/mat-views/victim-offenses.sql
@@ -70,4 +70,5 @@ create materialized view offense_victim_counts as
     SELECT *, 1992 as year FROM offense_victim_counts_1992 UNION
     SELECT *, 1991 as year FROM offense_victim_counts_1991;
 
-CREATE INDEX offense_victim_counts_state_id_idx ON offense_victim_counts (state_id);
+CREATE INDEX offense_victim_counts_state_id_idx ON offense_victim_counts (state_id, year, offense_name);
+CREATE INDEX offense_victim_counts_ori_idx ON offense_victim_counts (ori, year, offense_name);

--- a/dba/after_load/mat-views/victim.sql
+++ b/dba/after_load/mat-views/victim.sql
@@ -81,3 +81,6 @@ create materialized view victim_counts as
     SELECT *, 1993 as year FROM victim_counts_1993 UNION 
     SELECT *, 1992 as year FROM victim_counts_1992 UNION
     SELECT *, 1991 as year FROM victim_counts_1991;
+
+CREATE INDEX victim_counts_state_year_id_idx ON victim_counts (state_id, year);
+CREATE INDEX victim_counts_ori_year_idx ON victim_counts (ori, year);


### PR DESCRIPTION
So this PR makes these distinct value select queries perform a little better, by selecting distinct values from only the national level aggregations (rather than the full count tables). 

Downside: Distinct values are limited by year, so one year may have categories that another doesn't. However, one cool side effect would be that we can use this to detect the definition of a new category.

Example: 2014 may have 10 race definitions, and 2015 may have 11. This would mean that a definition was added in 2015. 