### PR TITLE
Suboffense query takes explorer_offense argument

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -473,6 +473,17 @@ class ExplorerOffenseMapping(object):
         'arson': 'arson'
     }
 
+    RETA_OFFENSE_CODE_MAPPING = {
+        'aggravated-assault': 'SUM_AST',
+        'burglary': 'SUM_BRG',
+        'larceny': 'SUM_LRC',
+        'motor-vehicle-theft': 'SUM_MVT',
+        'homicide': 'SUM_HOM',
+        'rape': 'SUM_RPE',
+        'robbery': 'SUM_ROB',
+        'arson': 'X_ARS'
+    }
+
     NIBRS_OFFENSE_MAPPING = {
         'aggravated-assault': 'Aggravated Assault',
         'burglary': 'Burglary/Breaking & Entering',
@@ -494,6 +505,10 @@ class ExplorerOffenseMapping(object):
     @property
     def reta_offense(self):
         return self.RETA_OFFENSE_MAPPING[self.offense]
+
+    @property
+    def reta_offense_code(self):
+        return self.RETA_OFFENSE_CODE_MAPPING[self.offense]
 
     @property
     def nibrs_offense(self):

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -97,10 +97,9 @@ class AgenciesSumsState(CdeResource):
     def get(self, args, state_abbr = None, agency_ori = None):
         self.verify_api_key(args)
         model = newmodels.AgencySums()
-        year = None
-        if 'year' in args:
-            year = args['year']
-        agency_sums = model.get(state = state_abbr, agency = agency_ori, year = year)
+        year = args.get('year', None)
+        explorer_offense = args.get('explorer_offense', None)
+        agency_sums = model.get(state = state_abbr, agency = agency_ori, year = year, explorer_offense = explorer_offense)
         filename = 'agency_sums_state'
         return self.render_response(agency_sums, args, csv_filename=filename)
 


### PR DESCRIPTION
Fixes #517, but the front end will have to do the grouping for now. In the long run, I think we should make a version of the agencies_sums_view table with some grouping like the reta_month_offense_subcat_summary table.