### PR TITLE
Aggravated assault should not include simple assault

### DIFF
--- a/crime_data/common/base.py
+++ b/crime_data/common/base.py
@@ -466,7 +466,6 @@ class ExplorerOffenseMapping(object):
     """For mapping from explorer offenses to SRS and NIBRS"""
 
     RETA_OFFENSE_MAPPING = {
-        'aggravated-assault': 'assault',
         'burglary': 'burglary',
         'larceny': 'larceny',
         'motor-vehicle-theft': 'motor vehicle theft',
@@ -477,7 +476,7 @@ class ExplorerOffenseMapping(object):
     }
 
     RETA_OFFENSE_CODE_MAPPING = {
-        'aggravated-assault': 'SUM_AST',
+        'aggravated-assault': 'X_AGG',
         'burglary': 'SUM_BRG',
         'larceny': 'SUM_LRC',
         'motor-vehicle-theft': 'SUM_MVT',


### PR DESCRIPTION
Fixes #565 

The DB changes are already in production, and we now match the Crime in the United States numbers for violent offenses (they use actual count, we use reported though so we're slightly higher). To make the aggravated assault numbers match, you must merge this.