### PR TITLE
Add past_10_years_reported to cde_agencies

### DIFF
--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -508,6 +508,7 @@ class CdeAgency(db.Model, FilterableModel):
     core_city_flag = db.Column(db.String(1))
     months_reported = db.Column(db.SmallInteger)
     nibrs_months_reported = db.Column(db.SmallInteger)
+    past_10_years_reported = db.Column(db.SmallInteger)
     covered_by_id = db.Column(db.BigInteger)
     covered_by_ori = db.Column(db.String(9))
     covered_by_name = db.Column(db.String(100))

--- a/crime_data/static/swagger.json
+++ b/crime_data/static/swagger.json
@@ -678,6 +678,15 @@
           "minimum": 0,
           "maximum": 12
         },
+        "past_10_years_reported": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "A count of how  many of the 10 most recent years of SRS data this agency reported 12 months of crime dats to the FBI.",
+          "minimum": 0,
+          "maximum": 10
+        },
         "covered_by_ori": {
           "type": [
             "string",

--- a/dba/after_load/denorm-agencies.sql
+++ b/dba/after_load/denorm-agencies.sql
@@ -1,5 +1,21 @@
 \set ON_ERROR_STOP on
 
+DO $$
+DECLARE
+max_year smallint;
+BEGIN
+max_year := (SELECT MAX(year) from agency_participation);
+
+DROP TABLE IF EXISTS ten_year_participation;
+CREATE TABLE ten_year_participation AS
+SELECT agency_id,
+SUM(reported) AS years_reporting
+FROM agency_participation
+WHERE year <= max_year
+AND year > max_year - 10
+GROUP BY agency_id;
+END $$;
+
 DROP TABLE IF EXISTS denorm_agencies_temp CASCADE;
 CREATE TABLE denorm_agencies_temp
 (
@@ -35,6 +51,7 @@ CREATE TABLE denorm_agencies_temp
     core_city_flag character varying(1),
     months_reported smallint,
     nibrs_months_reported smallint,
+    past_10_years_reported smallint,
     covered_by_id bigint,
     covered_by_ori character(9),
     covered_by_name character varying(100),
@@ -96,6 +113,7 @@ rap.suburban_area_flag,
 rac.core_city_flag,
 cap.months_reported,
 cap.nibrs_months_reported AS nibrs_months_reported,
+tp.years_reporting AS past_10_years_reported,
 racp.covered_by_agency_id AS covered_by_id,
 covering.ori AS covered_by_ori,
 covering.pub_agency_name AS covered_by_name,
@@ -118,7 +136,10 @@ LEFT OUTER JOIN cde_counties cc ON cc.county_id=rac.county_id
 LEFT OUTER JOIN ref_population_group rpg ON rpg.population_group_id=rap.population_group_id
 LEFT OUTER JOIN ref_agency_covered_by_flat racp ON racp.agency_id=ra.agency_id AND racp.data_year=y.current_year
 LEFT OUTER JOIN ref_agency covering ON covering.agency_id=racp.covered_by_agency_id
-LEFT OUTER JOIN pe_employee_data ped ON ped.agency_id=ra.agency_id AND ped.data_year=pe.staffing_year;
+LEFT OUTER JOIN pe_employee_data ped ON ped.agency_id=ra.agency_id AND ped.data_year=pe.staffing_year
+LEFT OUTER JOIN ten_year_participation tp ON tp.agency_id = ra.agency_id;
+
+DROP TABLE ten_year_participation;
 
 ALTER TABLE denorm_agencies_temp ENABLE TRIGGER ALL;
 DROP TABLE IF EXISTS cde_agencies CASCADE;


### PR DESCRIPTION
Fixes #569

This is a measure of how many times in the past decade of SRS reports, the given agency has reported 12 months of data. This is relative to the most recent year of SRS reports not the current calendar year (so for instance, right now we only have 2014 data so it's counting the years 2005-2014).

This column is already in the production DB. Just needs this PR merged for it to appear.