### PR TITLE
Revert "Set Surrogate-Control Header to cache responses for an hour"

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -121,8 +121,6 @@ def add_resources(app):
         resp.headers.extend(headers or {})
         return resp
 
-
-
     api.add_resource(crime_data.resources.agencies.AgenciesList, '/agencies')
     api.add_resource(crime_data.resources.participation.AgenciesParticipation,
                      '/agencies/participation',

--- a/crime_data/resources/arson.py
+++ b/crime_data/resources/arson.py
@@ -28,4 +28,4 @@ class ArsonStateCounts(CdeResource):
         query = query.filter(ArsonSummary.year != None)
         query = query.filter(ArsonSummary.subcategory_code == None)
         query = query.order_by(ArsonSummary.year)
-        return self.with_metadata(query, args), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(query, args)

--- a/crime_data/resources/cargo_theft.py
+++ b/crime_data/resources/cargo_theft.py
@@ -28,7 +28,7 @@ class CargoTheftsCountStates(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.CargoTheftCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class CargoTheftsCountAgencies(CdeResource):
@@ -44,7 +44,7 @@ class CargoTheftsCountAgencies(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.CargoTheftCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class CargoTheftsCountNational(CdeResource):
@@ -60,7 +60,7 @@ class CargoTheftsCountNational(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.CargoTheftCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class CargoTheftOffenseSubcounts(CdeResource):
@@ -82,4 +82,4 @@ class CargoTheftOffenseSubcounts(CdeResource):
                                                      state_id=state_id,
                                                      state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)

--- a/crime_data/resources/hate_crime.py
+++ b/crime_data/resources/hate_crime.py
@@ -26,7 +26,7 @@ class HateCrimesCountStates(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.HateCrimeCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class HateCrimesCountAgencies(CdeResource):
@@ -41,7 +41,7 @@ class HateCrimesCountAgencies(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.HateCrimeCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class HateCrimesCountNational(CdeResource):
@@ -56,7 +56,7 @@ class HateCrimesCountNational(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.HateCrimeCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class HateCrimeOffenseSubcounts(CdeResource):
@@ -78,4 +78,4 @@ class HateCrimeOffenseSubcounts(CdeResource):
                                                     state_id=state_id,
                                                     state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)

--- a/crime_data/resources/human_traffic.py
+++ b/crime_data/resources/human_traffic.py
@@ -16,7 +16,7 @@ class HtAgencyList(CdeResource):
     @cache(max_age=DEFAULT_MAX_AGE, public=True)
     @tuning_page
     def get(self, args):
-        return self._get(args), 200, {'Surrogate-Control':3600}
+        return self._get(args)
 
 
 class HtStatesList(CdeResource):
@@ -30,4 +30,4 @@ class HtStatesList(CdeResource):
         year = args.get('year', None)
         state_abbr = args.get('state_abbr', None)
         counts = HtSummary.grouped_by_state(year=year, state_abbr=state_abbr)
-        return self.render_response(counts, args, csv_filename='human_trafficking'), 200, {'Surrogate-Control':3600}
+        return self.render_response(counts, args, csv_filename='human_trafficking')

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -59,7 +59,7 @@ class AgenciesSumsState(CdeResource):
         explorer_offense = args.get('explorer_offense', None)
         agency_sums = model.get(state = state_abbr, agency = agency_ori, year = year, explorer_offense = explorer_offense)
         filename = 'agency_sums_state'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)
 
 
 class AgenciesSumsCounty(CdeResource):
@@ -81,7 +81,7 @@ class AgenciesSumsCounty(CdeResource):
         explorer_offense = args.get('explorer_offense', None)
         agency_sums = model.get(agency = agency_ori, year =  year, county = county_fips_code, state=state_abbr, explorer_offense=explorer_offense)
         filename = 'agency_sums_county'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)
 
 
 class AgenciesOffensesCount(CdeResource):
@@ -105,7 +105,7 @@ class AgenciesOffensesCount(CdeResource):
         else:
             agency_sums = newmodels.AgencyOffenseCounts().get(state = state_abbr, agency = agency_ori, year = year, explorer_offense = explorer_offense)
         filename = 'agency_offenses_state'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)
 
 
 class AgenciesOffensesCountyCount(CdeResource):
@@ -127,4 +127,4 @@ class AgenciesOffensesCountyCount(CdeResource):
         explorer_offense = args.get('explorer_offense', None)
         agency_sums = model.get(agency = agency_ori, year =  year, county = county_fips_code, state=state_abbr, explorer_offense=explorer_offense)
         filename = 'agency_sums_county'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)

--- a/crime_data/resources/offenders.py
+++ b/crime_data/resources/offenders.py
@@ -28,7 +28,7 @@ class OffendersCountNational(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.OffenderCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class OffendersCountStates(CdeResource):
@@ -44,7 +44,7 @@ class OffendersCountStates(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.OffenderCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 class OffendersCountAgencies(CdeResource):
     schema = False
@@ -59,7 +59,7 @@ class OffendersCountAgencies(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.OffenderCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class OffenderOffenseSubcounts(CdeResource):
@@ -81,4 +81,4 @@ class OffenderOffenseSubcounts(CdeResource):
                                                    state_id=state_id,
                                                    state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -20,7 +20,7 @@ class OffensesList(CdeResource):
     def get(self, args):
         self.verify_api_key(args)
         result = models.CrimeType.query
-        return self.with_metadata(result, args), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(result, args)
 
 
 class OffensesCountNational(CdeResource):
@@ -38,7 +38,7 @@ class OffensesCountNational(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.OffenseCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class OffensesCountStates(CdeResource):
@@ -56,7 +56,7 @@ class OffensesCountStates(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.OffenseCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class OffensesCountAgencies(CdeResource):
@@ -72,7 +72,7 @@ class OffensesCountAgencies(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.OffenseCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class OffenseByOffenseTypeSubcounts(CdeResource):
@@ -96,4 +96,4 @@ class OffenseByOffenseTypeSubcounts(CdeResource):
                                                         state_abbr=state_abbr)
         results = model.query(args)
         print(results)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)

--- a/crime_data/resources/participation.py
+++ b/crime_data/resources/participation.py
@@ -25,7 +25,7 @@ class StateParticipation(CdeResource):
         state = cdemodels.CdeRefState.get(abbr=state_abbr, state_id=state_id).one()
         rates = cdemodels.CdeParticipationRate(state_id=state.state_id).query.order_by('year DESC').all()
         filename = '{}_state_participation'.format(state.state_postal_abbr)
-        return self.render_response(rates, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(rates, args, csv_filename=filename)
 
 
 class NationalParticipation(CdeResource):
@@ -43,7 +43,7 @@ class NationalParticipation(CdeResource):
         rates = rates.filter(newmodels.ParticipationRate.county_id == None)
         rates = rates.order_by('year DESC').all()
         filename = 'participation_rates'
-        return self.render_response(rates, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(rates, args, csv_filename=filename)
 
 
 class AgenciesParticipation(CdeResource):
@@ -56,4 +56,4 @@ class AgenciesParticipation(CdeResource):
     @cache(max_age=DEFAULT_MAX_AGE, public=True)
     @tuning_page
     def get(self, args):
-        return self._get(args, csv_filename='agency_participation'), 200, {'Surrogate-Control':3600}
+        return self._get(args, csv_filename='agency_participation')

--- a/crime_data/resources/victims.py
+++ b/crime_data/resources/victims.py
@@ -30,7 +30,7 @@ class VictimsCountNational(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.VictimCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class VictimsCountStates(CdeResource):
@@ -49,7 +49,7 @@ class VictimsCountStates(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.VictimCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class VictimsCountAgencies(CdeResource):
@@ -66,7 +66,7 @@ class VictimsCountAgencies(CdeResource):
         self.verify_api_key(args)
         model = cdemodels.VictimCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)
 
 
 class VictimOffenseSubcounts(CdeResource):
@@ -89,4 +89,4 @@ class VictimOffenseSubcounts(CdeResource):
                                                  state_id=state_id,
                                                  state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(results.fetchall(), args, self.schema)


### PR DESCRIPTION
Reverts 18F/crime-data-api#587

Right now this is crashing CSV downloads of API endpoints. I have a more involved fix to restore it, but best to save that for the next sprint