### PR TITLE
WIP: Fixing a few things around CSV responses

### DIFF
--- a/crime_data/app.py
+++ b/crime_data/app.py
@@ -20,8 +20,8 @@ import crime_data.resources.hate_crime
 import crime_data.resources.geo
 import crime_data.resources.participation
 import crime_data.resources.estimates
-
 import crime_data.resources.human_traffic
+
 from werkzeug.contrib.fixers import ProxyFix
 
 from crime_data import commands
@@ -29,7 +29,7 @@ from crime_data.assets import assets
 from crime_data.common.marshmallow_schemas import ma
 from crime_data.common.models import db
 from crime_data.common.credentials import get_credential
-from crime_data.extensions import (cache, debug_toolbar, migrate, cache_control)
+from crime_data.extensions import (cache, debug_toolbar, migrate)
 from crime_data.settings import ProdConfig
 
 if __name__ == '__main__':
@@ -63,7 +63,6 @@ def register_extensions(app):
     ma.init_app(app)
     debug_toolbar.init_app(app)
     migrate.init_app(app, db)
-    cache_control.init_app(app)
     CORS(app)
     return None
 
@@ -120,7 +119,6 @@ def add_resources(app):
         resp = api.make_response(outfile.read(), code)
         resp.headers.extend(headers or {})
         return resp
-
 
 
     api.add_resource(crime_data.resources.agencies.AgenciesList, '/agencies')

--- a/crime_data/extensions.py
+++ b/crime_data/extensions.py
@@ -4,8 +4,8 @@ from flask_caching import Cache
 from flask_debugtoolbar import DebugToolbarExtension
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy as SQLAlchemyBase
-from flask.ext.cachecontrol import FlaskCacheControl
 from sqlalchemy.pool import NullPool
+from flask import make_response, request
 
 class SQLAlchemy(SQLAlchemyBase):
   def apply_driver_hacks(self, app, info, options):
@@ -18,7 +18,7 @@ db = SQLAlchemy()
 migrate = Migrate()
 cache = Cache()
 debug_toolbar = DebugToolbarExtension()
-cache_control = FlaskCacheControl()
 
 # Going to go with 7 minutes because it's prime
 DEFAULT_MAX_AGE = 420
+DEFAULT_SURROGATE_AGE = 3600

--- a/crime_data/resources/agencies.py
+++ b/crime_data/resources/agencies.py
@@ -2,13 +2,12 @@ import re
 
 from flask import jsonify
 from webargs.flaskparser import use_args
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 
 from crime_data.common import cdemodels, models, newmodels
 from crime_data.common.newmodels import CdeAgency
 from crime_data.common import marshmallow_schemas
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, cache_for
 from crime_data.common.marshmallow_schemas import (AgencySchema,
                                                    ArgumentsSchema)
 
@@ -18,7 +17,7 @@ class AgenciesList(CdeResource):
     tables = CdeAgency
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     def get(self, args):
         return self._get(args)
 
@@ -26,7 +25,7 @@ class AgenciesList(CdeResource):
 class AgenciesDetail(CdeResource):
     schema = marshmallow_schemas.AgencySchema()
     @use_args(marshmallow_schemas.ApiKeySchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     def get(self, args, ori):
         self.verify_api_key(args)
         agency = CdeAgency.query.filter(CdeAgency.ori == ori).one()

--- a/crime_data/resources/arrests.py
+++ b/crime_data/resources/arrests.py
@@ -1,9 +1,8 @@
 from webargs.flaskparser import use_args
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 
 from crime_data.common import cdemodels, marshmallow_schemas
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, cache_for
 
 
 
@@ -102,5 +101,5 @@ for different domains.
  ASR_VAG             | Vagrancy
  ASR_VAN             | Vandalism
  ASR_WEAP            | Weapons: Carrying, Possessing, Etc.
- ASR_ZERO            | Zero Report
+ ASR_ZERO            | Zero Reporty
 """

--- a/crime_data/resources/cargo_theft.py
+++ b/crime_data/resources/cargo_theft.py
@@ -1,10 +1,9 @@
 import decimal
 from webargs.flaskparser import use_args
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 
 from crime_data.common import cdemodels, marshmallow_schemas
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, cache_for
 
 # Template
 # variable => [prop_desc_name, location_name, victim_type_name, offense_name]
@@ -22,13 +21,13 @@ class CargoTheftsCountStates(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
         model = cdemodels.CargoTheftCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class CargoTheftsCountAgencies(CdeResource):
@@ -38,13 +37,13 @@ class CargoTheftsCountAgencies(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, ori, variable):
         self.verify_api_key(args)
         model = cdemodels.CargoTheftCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class CargoTheftsCountNational(CdeResource):
@@ -54,13 +53,13 @@ class CargoTheftsCountNational(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable):
         self.verify_api_key(args)
         model = cdemodels.CargoTheftCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema, csv_filename='ct_national')
 
 
 class CargoTheftOffenseSubcounts(CdeResource):
@@ -70,7 +69,7 @@ class CargoTheftOffenseSubcounts(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.OffenseCountViewArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable, state_id=None, state_abbr=None, ori=None):
         self.verify_api_key(args)
@@ -82,4 +81,4 @@ class CargoTheftOffenseSubcounts(CdeResource):
                                                      state_id=state_id,
                                                      state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema, csv_filename='cst_offense_count')

--- a/crime_data/resources/codes.py
+++ b/crime_data/resources/codes.py
@@ -1,9 +1,8 @@
 from flask import url_for, jsonify
 from webargs.flaskparser import use_args
-from flask.ext.cachecontrol import cache_for
 
 from crime_data.common import marshmallow_schemas, models
-from crime_data.common.base import CdeResource
+from crime_data.common.base import CdeResource, cache_for
 from crime_data.common.marshmallow_schemas import (ArgumentsSchema,
                                                    CodeIndexResponseSchema)
 
@@ -107,7 +106,7 @@ CODE_SCHEMAS = {
 
 
 class CodeReferenceIndex(CdeResource):
-    @cache_for(hours=1)
+    @cache_for(3600)
     def get(self):
         endpoints = {key: url_for('codereferencelist', code_table=key)
                      for key in CODE_SCHEMAS}
@@ -116,7 +115,7 @@ class CodeReferenceIndex(CdeResource):
 
 class CodeReferenceList(CdeResource):
     @use_args(ArgumentsSchema)
-    @cache_for(hours=1)
+    @cache_for(3600)
     def get(self, args, code_table, output=None):
         self.schema = CODE_SCHEMAS[code_table](many=True)
         output = args['output'] if output is None else output

--- a/crime_data/resources/geo.py
+++ b/crime_data/resources/geo.py
@@ -1,17 +1,16 @@
 from flask import jsonify
 from webargs.flaskparser import use_args
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 from marshmallow import fields
 from crime_data.common import cdemodels, marshmallow_schemas, models
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, cache_for
 
 
 class StateDetail(CdeResource):
     schema = marshmallow_schemas.StateDetailResponseSchema()
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, id):
         self.verify_api_key(args)
@@ -23,7 +22,7 @@ class CountyDetail(CdeResource):
     schema = marshmallow_schemas.CountyDetailResponseSchema()
 
     @use_args(marshmallow_schemas.ArgumentsSchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, fips):
         self.verify_api_key(args)

--- a/crime_data/resources/human_traffic.py
+++ b/crime_data/resources/human_traffic.py
@@ -16,7 +16,7 @@ class HtAgencyList(CdeResource):
     @cache(max_age=DEFAULT_MAX_AGE, public=True)
     @tuning_page
     def get(self, args):
-        return self._get(args), 200, {'Surrogate-Control':3600}
+        return self._get(args)
 
 
 class HtStatesList(CdeResource):
@@ -30,4 +30,4 @@ class HtStatesList(CdeResource):
         year = args.get('year', None)
         state_abbr = args.get('state_abbr', None)
         counts = HtSummary.grouped_by_state(year=year, state_abbr=state_abbr)
-        return self.render_response(counts, args, csv_filename='human_trafficking'), 200, {'Surrogate-Control':3600}
+        return self.render_response(counts, args, csv_filename='human_trafficking')

--- a/crime_data/resources/incidents.py
+++ b/crime_data/resources/incidents.py
@@ -1,9 +1,8 @@
 from webargs.flaskparser import use_args
 from itertools import filterfalse
 from crime_data.common import cdemodels, marshmallow_schemas, models, newmodels
-from crime_data.common.base import CdeResource, tuning_page, ExplorerOffenseMapping
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.common.base import CdeResource, tuning_page, ExplorerOffenseMapping, cache_for
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 from flask import jsonify
 
 def _is_string(col):
@@ -37,7 +36,7 @@ class CachedIncidentsCount(CdeResource):
                 field.load_only = field_name not in filtered_names
 
     @use_args(marshmallow_schemas.GroupableArgsSchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args):
         return self._get(args)
@@ -51,6 +50,7 @@ class AgenciesSumsState(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.OffenseCountViewArgs)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_abbr = None, agency_ori = None):
         self.verify_api_key(args)
@@ -59,7 +59,7 @@ class AgenciesSumsState(CdeResource):
         explorer_offense = args.get('explorer_offense', None)
         agency_sums = model.get(state = state_abbr, agency = agency_ori, year = year, explorer_offense = explorer_offense)
         filename = 'agency_sums_state'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)
 
 
 class AgenciesSumsCounty(CdeResource):
@@ -70,6 +70,7 @@ class AgenciesSumsCounty(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.OffenseCountViewArgsYear)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_abbr = None, county_fips_code = None, agency_ori = None):
         '''''
@@ -81,7 +82,7 @@ class AgenciesSumsCounty(CdeResource):
         explorer_offense = args.get('explorer_offense', None)
         agency_sums = model.get(agency = agency_ori, year =  year, county = county_fips_code, state=state_abbr, explorer_offense=explorer_offense)
         filename = 'agency_sums_county'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)
 
 
 class AgenciesOffensesCount(CdeResource):
@@ -92,6 +93,7 @@ class AgenciesOffensesCount(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.OffenseCountViewArgs)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_abbr = None, agency_ori = None):
         self.verify_api_key(args)
@@ -105,7 +107,7 @@ class AgenciesOffensesCount(CdeResource):
         else:
             agency_sums = newmodels.AgencyOffenseCounts().get(state = state_abbr, agency = agency_ori, year = year, explorer_offense = explorer_offense)
         filename = 'agency_offenses_state'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)
 
 
 class AgenciesOffensesCountyCount(CdeResource):
@@ -116,6 +118,7 @@ class AgenciesOffensesCountyCount(CdeResource):
     fast_count = True
 
     @use_args(marshmallow_schemas.OffenseCountViewArgsYear)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_abbr = None, county_fips_code = None, agency_ori = None):
         '''''
@@ -127,4 +130,4 @@ class AgenciesOffensesCountyCount(CdeResource):
         explorer_offense = args.get('explorer_offense', None)
         agency_sums = model.get(agency = agency_ori, year =  year, county = county_fips_code, state=state_abbr, explorer_offense=explorer_offense)
         filename = 'agency_sums_county'
-        return self.render_response(agency_sums, args, csv_filename=filename), 200, {'Surrogate-Control':3600}
+        return self.render_response(agency_sums, args, csv_filename=filename)

--- a/crime_data/resources/offenders.py
+++ b/crime_data/resources/offenders.py
@@ -1,10 +1,9 @@
 import json
 from webargs.flaskparser import use_args
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 
 from crime_data.common import cdemodels, marshmallow_schemas
-from crime_data.common.base import CdeResource, tuning_page, ExplorerOffenseMapping
+from crime_data.common.base import CdeResource, tuning_page, ExplorerOffenseMapping, cache_for
 
 # Template
 # variables => [location_type, offense_type, property_type, age, sex, race]
@@ -22,13 +21,13 @@ class OffendersCountNational(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable):
         self.verify_api_key(args)
         model = cdemodels.OffenderCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class OffendersCountStates(CdeResource):
@@ -38,13 +37,13 @@ class OffendersCountStates(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
         model = cdemodels.OffenderCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 class OffendersCountAgencies(CdeResource):
     schema = False
@@ -53,13 +52,13 @@ class OffendersCountAgencies(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, ori, variable):
         self.verify_api_key(args)
         model = cdemodels.OffenderCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class OffenderOffenseSubcounts(CdeResource):
@@ -69,7 +68,7 @@ class OffenderOffenseSubcounts(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.OffenseCountViewArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable, state_id=None, state_abbr=None, ori=None):
         self.verify_api_key(args)
@@ -81,4 +80,4 @@ class OffenderOffenseSubcounts(CdeResource):
                                                    state_id=state_id,
                                                    state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)

--- a/crime_data/resources/offenses.py
+++ b/crime_data/resources/offenses.py
@@ -1,9 +1,8 @@
 from webargs.flaskparser import use_args
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 
 from crime_data.common import models, cdemodels, marshmallow_schemas
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, cache_for
 from crime_data.common.marshmallow_schemas import ArgumentsSchema
 
 
@@ -16,11 +15,11 @@ class OffensesList(CdeResource):
     schema = marshmallow_schemas.CrimeTypeSchema(many=True)
 
     @use_args(ArgumentsSchema)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     def get(self, args):
         self.verify_api_key(args)
         result = models.CrimeType.query
-        return self.with_metadata(result, args), 200, {'Surrogate-Control':3600}
+        return self.with_metadata(result, args)
 
 
 class OffensesCountNational(CdeResource):
@@ -32,13 +31,13 @@ class OffensesCountNational(CdeResource):
     # schema = marshmallow_schemas.IncidentCountSchema()
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable):
         self.verify_api_key(args)
         model = cdemodels.OffenseCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class OffensesCountStates(CdeResource):
@@ -50,13 +49,13 @@ class OffensesCountStates(CdeResource):
     # schema = marshmallow_schemas.IncidentCountSchema()
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
         model = cdemodels.OffenseCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class OffensesCountAgencies(CdeResource):
@@ -66,13 +65,13 @@ class OffensesCountAgencies(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, ori, variable):
         self.verify_api_key(args)
         model = cdemodels.OffenseCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class OffenseByOffenseTypeSubcounts(CdeResource):
@@ -83,7 +82,7 @@ class OffenseByOffenseTypeSubcounts(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.OffenseCountViewArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable, state_id=None, state_abbr=None, ori=None):
         self.verify_api_key(args)
@@ -96,4 +95,4 @@ class OffenseByOffenseTypeSubcounts(CdeResource):
                                                         state_abbr=state_abbr)
         results = model.query(args)
         print(results)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)

--- a/crime_data/resources/victims.py
+++ b/crime_data/resources/victims.py
@@ -1,9 +1,8 @@
 from webargs.flaskparser import use_args
-from crime_data.extensions import DEFAULT_MAX_AGE
-from flask.ext.cachecontrol import cache
+from crime_data.extensions import DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE
 
 from crime_data.common import cdemodels, marshmallow_schemas
-from crime_data.common.base import CdeResource, tuning_page
+from crime_data.common.base import CdeResource, tuning_page, cache_for
 
 # Template
 # variables => [location_type, offense_type, property_type, age_num, sex_code, race_code]
@@ -24,13 +23,13 @@ class VictimsCountNational(CdeResource):
     # schema = marshmallow_schemas.IncidentCountSchema()
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable):
         self.verify_api_key(args)
         model = cdemodels.VictimCountView(variable, year=args['year'])
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class VictimsCountStates(CdeResource):
@@ -43,13 +42,13 @@ class VictimsCountStates(CdeResource):
     # schema = marshmallow_schemas.IncidentCountSchema()
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, state_id=None, state_abbr=None, variable=None):
         self.verify_api_key(args)
         model = cdemodels.VictimCountView(variable, year=args['year'], state_id=state_id, state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class VictimsCountAgencies(CdeResource):
@@ -60,13 +59,13 @@ class VictimsCountAgencies(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.IncidentViewCountArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, ori, variable):
         self.verify_api_key(args)
         model = cdemodels.VictimCountView(variable, year=args['year'], ori=ori)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)
 
 
 class VictimOffenseSubcounts(CdeResource):
@@ -77,7 +76,7 @@ class VictimOffenseSubcounts(CdeResource):
         return [dict(r) for r in data]
 
     @use_args(marshmallow_schemas.OffenseCountViewArgs)
-    @cache(max_age=DEFAULT_MAX_AGE, public=True)
+    @cache_for(DEFAULT_MAX_AGE, DEFAULT_SURROGATE_AGE)
     @tuning_page
     def get(self, args, variable, state_id=None, state_abbr=None, ori=None):
         self.verify_api_key(args)
@@ -89,4 +88,4 @@ class VictimOffenseSubcounts(CdeResource):
                                                  state_id=state_id,
                                                  state_abbr=state_abbr)
         results = model.query(args)
-        return self.with_metadata(results.fetchall(), args, self.schema), 200, {'Surrogate-Control':3600}
+        return self.render_response(results.fetchall(), args, self.schema)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -10,7 +10,6 @@ itsdangerous==0.24
 click>=5.0
 flask-httpauth
 Flask-Script>=0.6
-Flask-CacheControl==0.1.2
 Flask-cors==3.0.2
 
 # Database

--- a/tests/functional/test_agencies.py
+++ b/tests/functional/test_agencies.py
@@ -9,6 +9,8 @@ class TestAgenciesEndpoint:
     def test_agencies_endpoint_exists(self, testapp, swagger):
         res = testapp.get('/agencies')
         assert res.status_code == 200
+        assert res.headers['Cache-Control'] is not None
+        assert res.headers['Surrogate-Control'] is not None
         validate_api_call(swagger, raw_request=res.request, raw_response=res)
 
     def test_agencies_endpoint_returns_agencies(self, testapp, swagger):
@@ -34,6 +36,8 @@ class TestAgenciesEndpoint:
         id_no = self._single_ori(testapp)
         res = testapp.get('/agencies/{}'.format(id_no))
         assert res.status_code == 200
+        assert res.headers['Cache-Control'] is not None
+        assert res.headers['Surrogate-Control'] is not None
         validate_api_call(swagger, raw_request=res.request, raw_response=res)
 
     def test_agencies_paginate(self, testapp, swagger):
@@ -50,6 +54,9 @@ class TestAgenciesEndpoint:
 
     def test_agencies_offenses(self, testapp, swagger):
         res = testapp.get('/agencies/count/RI0040200/offenses?explorer_offense=robbery')
+        assert res.status_code == 200
+        assert res.headers['Cache-Control'] is not None
+        assert res.headers['Surrogate-Control'] is not None
         validate_api_call(swagger, raw_request=res.request, raw_response=res)
         assert len(res.json['results']) == 1
 

--- a/tests/functional/test_arson.py
+++ b/tests/functional/test_arson.py
@@ -10,9 +10,13 @@ class TestArsonCounts:
     def test_national_counts(self, testapp, swagger):
         res = testapp.get('/arson/national')
         assert res.status_code == 200
+        assert res.headers['Cache-Control'] is not None
+        assert res.headers['Surrogate-Control'] is not None
         validate_api_call(swagger, raw_request=res.request, raw_response=res)
 
     def test_state_counts(self, testapp, swagger):
         res = testapp.get('/arson/states/ri')
         assert res.status_code == 200
-        validate_api_call(swagger, raw_request=res.request, raw_response=res)
+        assert res.headers['Cache-Control'] is not None
+        assert res.headers['Surrogate-Control'] is not None
+        validate_api_call(swagger, raw_request=res.request,y raw_response=res)

--- a/tests/functional/test_offense_by_offense_types.py
+++ b/tests/functional/test_offense_by_offense_types.py
@@ -47,7 +47,7 @@ class TestOffenseByOffenseTypesEndpoint:
 
     @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
     def test_offenses_endpoint_with_state_year_offense(self, testapp, swagger, variable):
-        url = '/offenses/count/states/43/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)
+        url = '/offenses/count/states/44/{}/offenses?offense_name=Aggravated+Assault&year=2014'.format(variable)
         res = testapp.get(url)
         validate_api_call(swagger, raw_request=res.request, raw_response=res)
         assert 'pagination' in res.json
@@ -57,7 +57,7 @@ class TestOffenseByOffenseTypesEndpoint:
     @pytest.mark.parametrize('variable', OffenseByOffenseTypeCountView.VARIABLES)
     @pytest.mark.parametrize('explorer_offense', ExplorerOffenseMapping.NIBRS_OFFENSE_MAPPING.keys())
     def test_offenses_endpoint_with_state_year_explorer_offense(self, testapp, swagger, variable, explorer_offense):
-        url = '/offenses/count/states/43/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
+        url = '/offenses/count/states/44/{}/offenses?explorer_offense={}&year=2014'.format(variable, explorer_offense)
         res = testapp.get(url)
         validate_api_call(swagger, raw_request=res.request, raw_response=res)
         assert 'pagination' in res.json


### PR DESCRIPTION
The old PR for adding Surrogate-Control was trying to parse all responses into JSON which caused it to crash when the user provided the `output=csv` flag. So I decided to rewrite the wrapper for cache control to use our own wrapper that could take a surrogate caching time as well. This lets us remove one more dependency from the code. So now, we decorate API methods with

```python
@cache_for(public_caching_time, optional_surrogate_caching_time)
```

While I was at it, I decided to change it that all endpoints should call `CdeResource.render_response` instead of `with_metadata` to ensure that all paths return a Flask Response object. And I added some tests to look for caching headers for a few of them.

The issue that isn't working right now are the endpoints that use the database to generate JSON. Right now, the results are being escaped within a `"json_data": [...]` element and I don't know how to inline that JSON into the larger paginated JSON so I can avoid parsing it.

Also to be done: add more assertions to tests that we can download various endpoints as CSV data and that cache headers are correct