### PR TITLE
Use master app name

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ machine:
     CF_USERNAME: fbi-crime-explorer_deployer
     CF_ORGANIZATION: fbi-crime-explorer
     CF_SPACE: prototype
-    CF_APP: crime-data-api
     DATABASE_URL: "postgres://ubuntu@localhost/circle_test"
 dependencies:
   override:
@@ -29,4 +28,4 @@ deployment:
       - cf install-plugin autopilot -f -r CF-Community
       - cf api $CF_API
       - cf auth $CF_USERNAME $CF_PASSWORD && cf target -o $CF_ORGANIZATION -s $CF_SPACE
-      - cf zero-downtime-push $CF_APP -f manifests/master.yml -p .
+      - cf zero-downtime-push crime-data-api-master -f manifests/master.yml -p .


### PR DESCRIPTION
The manifest file was deploying our master app to the old URL and therefore removing the production instance. Changes so that the app is deployed with the proper app name