### PR TITLE
Add nibrs_start_year to cde agencies

### DIFF
--- a/crime_data/common/newmodels.py
+++ b/crime_data/common/newmodels.py
@@ -402,6 +402,7 @@ class CdeAgency(db.Model, FilterableModel):
     start_year = db.Column(db.SmallInteger)
     dormant_year = db.Column(db.SmallInteger)
     revised_rape_start = db.Column(db.SmallInteger)
+    current_nibrs_start_year = db.Column(db.SmallInteger)
     current_year = db.Column(db.SmallInteger)
     population = db.Column(db.BigInteger)
     population_group_code = db.Column(db.String(2))

--- a/crime_data/static/swagger.json
+++ b/crime_data/static/swagger.json
@@ -608,6 +608,13 @@
           ],
           "minimum": 2013
         },
+        "current_nibrs_start_year": {
+          "description": "If the agency is currently reporting 12 months of NIBRS data to the FBI, this is the first year that current run of reporting NIBRS data started. Because there are many agencies that reported NIBRS data in 1991 then stopped for many years before resuming in the 2000s, this is a better measure than the first year of NIBRS reporting.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "current_year": {
           "type": [
             "integer",

--- a/dba/after_load/denorm-agencies.sql
+++ b/dba/after_load/denorm-agencies.sql
@@ -154,7 +154,7 @@ LEFT OUTER JOIN agency_participation cap ON cap.agency_id=ra.agency_id AND cap.y
 LEFT OUTER JOIN ref_submitting_agency rsa ON rsa.agency_id=ra.submitting_agency_id
 LEFT OUTER JOIN ref_state rss ON rss.state_id=rsa.state_id
 LEFT OUTER JOIN ref_agency_population rap ON rap.agency_id=ra.agency_id AND rap.data_year=y.current_year
-LEFT OUTER JOIN (SELECT DISTINCT ON (agency_id, data_year) agency_id, data_year, county_id, core_city_flag FROM ref_agency_county ORDER BY agency_id, data_year, core_city_flag DESC) rac ON rac.agency_id=ra.agency_id AND rac.data_year=y.current_year
+LEFT OUTER JOIN (SELECT DISTINCT ON (agency_id, data_year) agency_id, data_year, county_id, core_city_flag FROM ref_agency_county ORDER BY agency_id, data_year, population DESC) rac ON rac.agency_id=ra.agency_id AND rac.data_year=y.current_year
 LEFT OUTER JOIN cde_counties cc ON cc.county_id=rac.county_id
 LEFT OUTER JOIN ref_population_group rpg ON rpg.population_group_id=rap.population_group_id
 LEFT OUTER JOIN ref_agency_covered_by_flat racp ON racp.agency_id=ra.agency_id AND racp.data_year=y.current_year


### PR DESCRIPTION
Fixes https://github.com/18F/crime-data-frontend/issues/732

This adds a new column `current_nibrs_start_year` to the agencies table that lists the first year of the current reporting run that an agency started reporting NIBRS data. Some sample situations and what this field would be

|Scenario|Current NIBRS Start Year|
|-|-|
|Agencry reported 1991 - |1991|
|Agency reported NIBRS 1991-1992, 2007-|2007|
|Agency never reported NIBRS|NULL|
|Agency reported 2006, 2008, 2010-2014|2010|
|Agency reported 2007-2010 (abandoned after)|2007|

It's not perfect, but it lets you at least set the start year for the NIBRS visualizations. Note that some agencies have been reporting NIBRS continuously since the early 90s

Also, fixes https://github.com/18F/crime-data-explorer/issues/252