### PR TITLE
Remove node build step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,5 +38,4 @@ deployment:
       - cf install-plugin autopilot -f -r CF-Community
       - cf api $CF_API
       - cf auth $CF_USERNAME $CF_PASSWORD && cf target -o $CF_ORGANIZATION -s $CF_SPACE
-      - npm run build
       - cf zero-downtime-push crime-data-api -f manifests/production.yml


### PR DESCRIPTION
Removing something I left in when I copied over these instructions from the front end. It looks identical, except for the manifest and app name used, to the master deployment now